### PR TITLE
Remove duplicate dependence.

### DIFF
--- a/client-js/package.json
+++ b/client-js/package.json
@@ -35,7 +35,6 @@
     "gulp-vulcanize": "^6.0.0",
     "jshint-stylish": "^2.0.0",
     "merge-stream": "^0.1.7",
-    "node-libs-browser": "^0.5.2",
     "opn": "^1.0.0",
     "require-dir": "^0.3.0",
     "run-sequence": "^1.0.2",


### PR DESCRIPTION
Based on my understanding of `package.json`, there was no reason for `"node-libs-browser"` to be in dependencies and devDependencies.
