### PR TITLE
Remove http api and allow server->client calls/notifications over jsonrpc

### DIFF
--- a/client-js/app/scripts/app.ts
+++ b/client-js/app/scripts/app.ts
@@ -25,7 +25,7 @@ window.addEventListener('WebComponentsReady', function() {
     page(e.detail.path);
   });
 
-  var socket = new rpc.JsonRpcSocket('ws://localhost:9000/api/socket2');
+  var socket = new rpc.JsonRpcSocket('ws://localhost:9000/api/socket');
   var mgr = new manager.ManagerServiceJsonRpc(socket);
   var reg = new registry.RegistryServiceJsonRpc(socket);
   var dv = new datavault.DataVaultService(socket);

--- a/client-js/app/scripts/app.ts
+++ b/client-js/app/scripts/app.ts
@@ -28,8 +28,7 @@ window.addEventListener('WebComponentsReady', function() {
   var socket = new rpc.JsonRpcSocket('ws://localhost:9000/api/socket2');
   var mgr = new manager.ManagerServiceJsonRpc(socket);
   var reg = new registry.RegistryServiceJsonRpc(socket);
-
-  var dv = new datavault.DataVaultService('http://localhost:9000');
+  var dv = new datavault.DataVaultService(socket);
 
   function pathStr(path: Array<string>, dir?: string): string {
     var url = '';

--- a/client-js/app/scripts/datavault.ts
+++ b/client-js/app/scripts/datavault.ts
@@ -1,4 +1,5 @@
 import promise = require('es6-promise');
+import rpc = require('./rpc');
 
 var Promise = promise.Promise;
 
@@ -12,40 +13,13 @@ export interface DataVaultApi {
   dir(path: Array<string>): Promise<DataVaultListing>;
 }
 
-export class DataVaultService implements DataVaultApi {
-  baseUrl: string;
+export class DataVaultService extends rpc.RpcService implements DataVaultApi {
 
-  constructor(baseUrl: string) {
-    this.baseUrl = baseUrl + '/api/vault';
+  constructor(socket: rpc.JsonRpcSocket) {
+    super(socket, 'org.labrad.datavault.');
   }
 
   dir(path: Array<string>): Promise<DataVaultListing> {
-    return this.sendRequest('/dir', path);
-  }
-
-  sendRequest(path: string, data: any): Promise<DataVaultListing> {
-    return new promise.Promise((resolve, reject) => {
-
-      var url = this.baseUrl + path;
-
-      var request = new XMLHttpRequest();
-      request.open('POST', url, true);
-      request.setRequestHeader('Content-Type', 'application/json; charset=UTF-8');
-      request.setRequestHeader('Access-Control-Allow-Origin', '*');
-
-      request.onload = function(e) {
-        if (request.status >= 200 && request.status < 400) {
-          resolve(<DataVaultListing>JSON.parse(request.responseText));
-        } else {
-          reject(new Error('request failed with status ' + request.status));
-        }
-      };
-
-      request.onerror = function(e) {
-        reject(new Error('request failed: ' + e));
-      };
-
-      request.send(JSON.stringify(data));
-    });
+    return this.call<DataVaultListing>('dir', [path]);
   }
 }

--- a/client-js/app/scripts/registry.ts
+++ b/client-js/app/scripts/registry.ts
@@ -26,6 +26,9 @@ export interface RegistryApi {
   renameDir(params: {path: Array<string>; dir: string; newDir: string}): Promise<RegistryListing>;
   copyDir(params: {path: Array<string>; dir: string; newPath: Array<string>; newDir: string}): Promise<RegistryListing>;
   moveDir(params: {path: Array<string>; dir: string; newPath: Array<string>; newDir: string}): Promise<RegistryListing>;
+
+  watch(params: {path: Array<string>}): Promise<void>;
+  unwatch(params: {path: Array<string>}): Promise<void>;
 }
 
 export class RegistryServiceJsonRpc extends rpc.RpcService implements RegistryApi {
@@ -69,6 +72,13 @@ export class RegistryServiceJsonRpc extends rpc.RpcService implements RegistryAp
   }
   moveDir(params: {path: Array<string>; dir: string; newPath: Array<string>; newDir: string}): Promise<RegistryListing> {
     return this.call<RegistryListing>('moveDir', params);
+  }
+
+  watch(params: {path: Array<string>}): Promise<void> {
+    return this.call<void>('watch', params);
+  }
+  unwatch(params: {path: Array<string>}): Promise<void> {
+    return this.call<void>('unwatch', params);
   }
 }
 

--- a/server/src/main/resources/routes
+++ b/server/src/main/resources/routes
@@ -27,8 +27,6 @@ POST    /api/registry/unwatch        org.labrad.browser.RegistryController.unwat
 
 GET     /api/servers/:name           org.labrad.browser.BrowserController.serverInfo(name)
 
-POST    /api/vault/dir               org.labrad.browser.VaultController.dir
-
 GET     /api/socket                  org.labrad.browser.WebSocketController.socket
 GET     /api/socket2                 org.labrad.browser.JsonRpcController.socket
 

--- a/server/src/main/resources/routes
+++ b/server/src/main/resources/routes
@@ -1,33 +1,5 @@
 GET     /     org.labrad.browser.BrowserController.index
 
-OPTIONS /api/*path                    org.labrad.browser.BrowserController.preflight(path)
-
-GET     /api/manager/connections      org.labrad.browser.BrowserController.connections
-DELETE  /api/manager/connections/:id  org.labrad.browser.BrowserController.connectionClose(id: Long)
-
-GET     /api/nodes                                org.labrad.browser.NodeController.allNodes
-POST    /api/nodes/:node/refresh                  org.labrad.browser.NodeController.refreshNode(node)
-POST    /api/nodes/:node/servers/:server/start    org.labrad.browser.NodeController.startServer(node, server)
-POST    /api/nodes/:node/servers/:server/stop     org.labrad.browser.NodeController.stopServer(node, server)
-POST    /api/nodes/:node/servers/:server/restart  org.labrad.browser.NodeController.restartServer(node, server)
-
-POST    /api/registry/dir            org.labrad.browser.RegistryController.dir
-POST    /api/registry/set            org.labrad.browser.RegistryController.set
-POST    /api/registry/del            org.labrad.browser.RegistryController.del
-POST    /api/registry/mkdir          org.labrad.browser.RegistryController.mkdir
-POST    /api/registry/rmdir          org.labrad.browser.RegistryController.rmdir
-POST    /api/registry/copy           org.labrad.browser.RegistryController.copy
-POST    /api/registry/copyDir        org.labrad.browser.RegistryController.copyDir
-POST    /api/registry/rename         org.labrad.browser.RegistryController.rename
-POST    /api/registry/renameDir      org.labrad.browser.RegistryController.renameDir
-POST    /api/registry/move           org.labrad.browser.RegistryController.move
-POST    /api/registry/moveDir        org.labrad.browser.RegistryController.moveDir
-POST    /api/registry/watch          org.labrad.browser.RegistryController.watch
-POST    /api/registry/unwatch        org.labrad.browser.RegistryController.unwatch
-
-GET     /api/servers/:name           org.labrad.browser.BrowserController.serverInfo(name)
-
-GET     /api/socket                  org.labrad.browser.WebSocketController.socket
-GET     /api/socket2                 org.labrad.browser.JsonRpcController.socket
+GET     /api/socket           org.labrad.browser.JsonRpcController.socket
 
 GET     /assets/*file         controllers.Assets.at(path="/public", file)

--- a/server/src/main/scala/org/labrad/browser/NodeController.scala
+++ b/server/src/main/scala/org/labrad/browser/NodeController.scala
@@ -1,7 +1,7 @@
 package org.labrad.browser
 
 import javax.inject._
-import org.labrad.browser.common.message.NodeServerStatus
+import org.labrad.browser.jsonrpc.{Call, Notify}
 import org.labrad.data._
 import org.labrad.util.Logging
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
@@ -10,13 +10,10 @@ import play.api.mvc._
 import scala.async.Async.{async, await}
 import scala.concurrent.Future
 
-object NodeController {
+
+object NodeApi {
   // json response types
-  case class ServerStatus(name: String, description: String, version: String, instanceName: String, environmentVars: Seq[String], instances: Seq[String]) {
-    def toJava: NodeServerStatus = {
-      new NodeServerStatus(name, description, version, instanceName, environmentVars.toArray, instances.toArray)
-    }
-  }
+  case class ServerStatus(name: String, description: String, version: String, instanceName: String, environmentVars: Seq[String], instances: Seq[String])
   object ServerStatus { implicit val format = Json.format[ServerStatus] }
 
   case class NodeStatus(name: String, servers: Seq[ServerStatus])
@@ -30,32 +27,30 @@ object NodeController {
   }
 }
 
-class NodeController @Inject() (cxnHolder: LabradConnectionHolder) extends Controller with Logging {
-  import NodeController._
+class NodeApi(cxn: LabradConnection) extends Logging {
+  import NodeApi._
 
-  def allNodes = Action.async { request =>
+  def allNodes(): Future[Seq[NodeStatus]] = {
     async {
-      val serverData = await { cxnHolder.cxn.manager.servers() }
+      val serverData = await { cxn.manager.servers() }
       val servers = serverData.map { case (id, name) => name }
 
       val nodes = servers.filter(_.toLowerCase.startsWith("node"))
       val futures = nodes.map { node =>
-        cxnHolder.cxn.to(node).call("status").map((node, _))
+        cxn.to(node).call("status").map((node, _))
       }
       val results = await { Future.sequence(futures) }
 
-      val statuses = results.map { case (node, servers) =>
+      results.map { case (node, servers) =>
         NodeStatus(node, getServerStatuses(servers))
       }
-
-      Ok(Json.toJson(statuses))
     }
   }
 
-  def refreshNode(node: String) = Action.async {
+  def refreshNode(node: String): Future[String] = {
     log.info(s"refreshServers. node=$node")
-    cxnHolder.cxn.to(node).call("refresh_servers").map { _ =>
-      Ok(Json.toJson("refreshed"))
+    cxn.to(node).call("refresh_servers").map { _ =>
+      "refreshed"
     }
   }
 
@@ -63,10 +58,20 @@ class NodeController @Inject() (cxnHolder: LabradConnectionHolder) extends Contr
   def startServer(node: String, server: String) = doRequest(node, server, "start")
   def stopServer(node: String, server: String) = doRequest(node, server, "stop")
 
-  private def doRequest(node: String, server: String, action: String) = Action.async {
-    val pkt = cxnHolder.cxn.to(node).packet()
+  private def doRequest(node: String, server: String, action: String): Future[String] = {
+    val pkt = cxn.to(node).packet()
     val req = pkt.call(action, Str(server))
     pkt.send
-    req.map { r => Ok(Json.toJson(r.getString)) }
+    req.map { _.getString }
   }
+}
+
+trait NodeClientApi {
+  import NodeApi._
+
+  @Notify("org.labrad.node.nodeStatus")
+  def nodeStatus(name: String, servers: Seq[ServerStatus]): Unit
+
+  @Notify("org.labrad.node.serverStatus")
+  def serverStatus(node: String, server: String, instance: String, status: String /*InstanceStatus*/): Unit
 }

--- a/server/src/main/scala/org/labrad/browser/RegistryController.scala
+++ b/server/src/main/scala/org/labrad/browser/RegistryController.scala
@@ -13,7 +13,7 @@ import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 
 
-object RegistryController {
+object RegistryApi {
   /**
    * Convert a path to an absolute path, by prepending an empty segment, if needed
    */
@@ -27,264 +27,18 @@ object RegistryController {
 }
 
 
-class RegistryController @Inject() (cxnHolder: LabradConnectionHolder) extends Controller with JsonRpc {
-
-  import RegistryController._
-
-  // json request/response types
-  case class RegistryListing(path: Seq[String], dirs: Seq[String], keys: Seq[String], vals: Seq[String])
-  object RegistryListing { implicit val format = Json.format[RegistryListing] }
-
-  case class Set(path: Seq[String], key: String, value: String)
-  object Set { implicit val format = Json.format[Set] }
-
-  case class Del(path: Seq[String], key: String)
-  object Del { implicit val format = Json.format[Del] }
-
-  case class MkDir(path: Seq[String], dir: String)
-  object MkDir { implicit val format = Json.format[MkDir] }
-
-  case class RmDir(path: Seq[String], dir: String)
-  object RmDir { implicit val format = Json.format[RmDir] }
-
-  case class Copy(path: Seq[String], key: String, newPath: Seq[String], newKey: String)
-  object Copy { implicit val format = Json.format[Copy] }
-
-  case class CopyDir(path: Seq[String], dir: String, newPath: Seq[String], newDir: String)
-  object CopyDir { implicit val format = Json.format[CopyDir] }
-
-  case class Rename(path: Seq[String], key: String, newKey: String)
-  object Rename { implicit val format = Json.format[Rename] }
-
-  case class RenameDir(path: Seq[String], dir: String, newDir: String)
-  object RenameDir { implicit val format = Json.format[RenameDir] }
-
-  case class Move(path: Seq[String], key: String, newPath: Seq[String], newKey: String)
-  object Move { implicit val format = Json.format[Move] }
-
-  case class MoveDir(path: Seq[String], dir: String, newPath: Seq[String], newDir: String)
-  object MoveDir { implicit val format = Json.format[MoveDir] }
-
-  case class Watch(id: String, watchId: String, path: String)
-  object Watch { implicit val format = Json.format[Watch] }
-
-  case class Unwatch(id: String, watchId: String)
-  object Unwatch { implicit val format = Json.format[Unwatch] }
-
-
-  // registry utility functions
-
-  private def startPacket(path: Seq[String], create: Boolean = false) = {
-    val pkt = cxnHolder.cxn.registry.packet()
-    pkt.cd(absPath(path), create = create)
-    pkt
-  }
-
-  private def dumbPacket(path: Seq[String], create: Boolean = false) = {
-    val pkt = cxnHolder.cxn.registry.packet()
-    //pkt.cd(absPath(path), create = create)
-    pkt
-  }
-
-  private def regDir(path: Seq[String]): Future[RegistryListing] = {
-    // get directory listing
-    val pkt = startPacket(path)
-    val dirF = pkt.dir()
-    pkt.send()
-    dirF.flatMap { case (dirsRaw, keysRaw) =>
-
-      val dirs = dirsRaw.sorted
-      val keys = keysRaw.sorted
-
-      val valsF = if (keys.size == 0) {
-        Future.successful(Seq.empty[String])
-      } else {
-        // get the values of all keys
-        val pkt = startPacket(path)
-        val fs = keys.map(key => pkt.get(key))
-        pkt.send()
-        Future.sequence(fs)
-      }
-
-      valsF.map { vals =>
-        RegistryListing(path, dirs, keys, vals.map(_.toString))
-      }
-    }
-  }
-
-  private def regDel(path: Seq[String], key: String): Future[Unit] = async {
-    val pkt = startPacket(path)
-    pkt.del(key)
-    await { pkt.send() }
-  }
-
-  private def regRmdir(path: Seq[String], dir: String): Future[Unit] = async {
-     // remove all subdirectories
-    val subPath = path :+ dir
-    val ls = await { regDir(subPath) }
-    val subDirs = ls.dirs.map { subDir => regRmdir(subPath, subDir) }
-    await { Future.sequence(subDirs) }
-
-    // remove all keys
-    if (ls.keys.size > 0) {
-      val pkt = startPacket(subPath)
-      for (key <- ls.keys)
-        pkt.call("del", Str(key))
-      await { pkt.send() }
-    }
-
-    // remove the directory itself
-    val pkt = startPacket(path)
-    pkt.rmDir(dir)
-    await { pkt.send() }
-  }
-
-  private def regCopy(path: Seq[String], key: String, newPath: Seq[String], newKey: String): Future[Unit] = async {
-    val p1 = startPacket(path)
-    val dataF = p1.get(key)
-    p1.send()
-    val value = await { dataF }
-
-    val p2 = startPacket(newPath)
-    p2.set(newKey, value)
-    await { p2.send() }
-  }
-
-  private def regCopyDir(path: Seq[String], dir: String, newPath: Seq[String], newDir: String): Future[Unit] = async {
-    // if newDir does not exist, create it
-    val listing = await { regDir(newPath) }
-    if (!listing.dirs.contains(newDir)) {
-      val pkt = startPacket(path)
-      pkt.mkDir(newDir)
-      await { pkt.send() }
-    }
-
-    val subpath = path :+ dir
-    val newSubpath = newPath :+ newDir
-    val subListing = await { regDir(subpath) }
-
-    // recursively copy all subdirectories
-    val dirCopies = subListing.dirs.map { subdir =>
-      regCopyDir(subpath, subdir, newSubpath, subdir)
-    }
-    await { Future.sequence(dirCopies) }
-
-    // copy all keys
-    val keyCopies = subListing.keys.map { key =>
-      regCopy(subpath, key, newSubpath, key)
-    }
-    await { Future.sequence(keyCopies) }
-  }
-
-  private def regMove(path: Seq[String], key: String, newPath: Seq[String], newKey: String): Future[RegistryListing] = async {
-    if (absPath(path) != absPath(newPath) || newKey != key) {
-      await { regCopy(path, key, newPath, newKey) }
-      await { regDel(path, key) }
-    }
-    await { regDir(newPath) }
-  }
-
-  private def regMoveDir(path: Seq[String], dir: String, newPath: Seq[String], newDir: String): Future[RegistryListing] = async {
-    if (absPath(path) != absPath(newPath) || newDir != dir) {
-      await { regCopyDir(path, dir, newPath, newDir) }
-      await { regRmdir(path, dir) }
-    }
-    await { regDir(newPath) }
-  }
-
-
-
-  // callable RPCs
-
-  def dir = rpc[Seq[String], RegistryListing] { path =>
-    regDir(path)
-  }
-
-  def set = rpc[Set, RegistryListing] { case Set(path, key, value) =>
-    val data = Data.parse(value)
-    val pkt = startPacket(path)
-    pkt.set(key, data)
-    async {
-      await { pkt.send() }
-      await { regDir(path) }
-    }
-  }
-
-  def del = rpc[Del, RegistryListing] { case Del(path, key) =>
-    async {
-      await { regDel(path, key) }
-      await { regDir(path) }
-    }
-  }
-
-  def mkdir = rpc[MkDir, RegistryListing] { case MkDir(path, dir) =>
-    val pkt = startPacket(path)
-    pkt.mkDir(dir)
-    async {
-      await { pkt.send() }
-      await { regDir(path) }
-    }
-  }
-
-  def rmdir = rpc[RmDir, RegistryListing] { case RmDir(path, dir) =>
-    async {
-      await { regRmdir(path, dir) }
-      await { regDir(path) }
-    }
-  }
-
-  def copy = rpc[Copy, RegistryListing] { case Copy(path, key, newPath, newKey) =>
-    async {
-      await { regCopy(path, key, newPath, newKey) }
-      await { regDir(newPath) }
-    }
-  }
-
-  def copyDir = rpc[CopyDir, RegistryListing] { case CopyDir(path, dir, newPath, newDir) =>
-    async {
-      await { regCopyDir(path, dir, newPath, newDir) }
-      await { regDir(newPath) }
-    }
-  }
-
-  def rename = rpc[Rename, RegistryListing] { case Rename(path, key, newKey) =>
-    regMove(path, key, path, newKey)
-  }
-
-  def renameDir = rpc[RenameDir, RegistryListing] { case RenameDir(path, dir, newDir) =>
-    regMoveDir(path, dir, path, newDir)
-  }
-
-  def move = rpc[Move, RegistryListing] { case Move(path, key, newPath, newKey) =>
-    regMove(path, key, newPath, newKey)
-  }
-
-  def moveDir = rpc[MoveDir, RegistryListing] { case MoveDir(path, dir, newPath, newDir) =>
-    regMoveDir(path, dir, newPath, newDir)
-  }
-
-  def watch = rpc[Watch, String] { case Watch(id, watchId, path) =>
-    ???
-  }
-
-  def unwatch = rpc[Unwatch, String] { case Unwatch(id, watchId) =>
-    ???
-  }
-}
-
-
 case class RegistryListing(path: Seq[String], dirs: Seq[String], keys: Seq[String], vals: Seq[String])
 object RegistryListing { implicit val format = Json.format[RegistryListing] }
 
-class RegistryApi(cxnHolder: LabradConnectionHolder, client: RegistryClientApi) extends Logging {
+class RegistryApi(cxn: LabradConnection, client: RegistryClientApi) extends Logging {
 
-  import RegistryController._
+  import RegistryApi._
 
 
   // registry utility functions
 
   private def startPacket(path: Seq[String], create: Boolean = false) = {
-    val pkt = cxnHolder.cxn.registry.packet()
+    val pkt = cxn.registry.packet()
     pkt.cd(absPath(path), create = create)
     pkt
   }
@@ -399,7 +153,7 @@ class RegistryApi(cxnHolder: LabradConnectionHolder, client: RegistryClientApi) 
 
   @Call("org.labrad.manager.echo")
   def dumbEcho(inp: String): Future[String] = {
-    cxnHolder.cxn.get.send("manager", ("echo", Str(inp))).map { results => results(0).get[String] }
+    cxn.get.send("manager", ("echo", Str(inp))).map { results => results(0).get[String] }
   }
 
   @Call("org.labrad.registry.dir")
@@ -484,8 +238,7 @@ class RegistryApi(cxnHolder: LabradConnectionHolder, client: RegistryClientApi) 
   @Call("org.labrad.registry.watch")
   def watch(path: Seq[String]): Unit = synchronized {
     try {
-      val cxn = cxnHolder.cxn.get
-      val ctx = cxn.newContext
+      val ctx = cxn.get.newContext
       val msgId = ctx.low
       nextMessageId += 1
       val listener: Listener = {
@@ -496,9 +249,9 @@ class RegistryApi(cxnHolder: LabradConnectionHolder, client: RegistryClientApi) 
             if (addOrChange) client.keyChanged(path, name) else client.keyRemoved(path, name)
           }
       }
-      cxn.addMessageListener(listener)
+      cxn.get.addMessageListener(listener)
 
-      val reg = cxnHolder.cxn.registry
+      val reg = cxn.registry
       val pkt = reg.packet(ctx)
       pkt.cd(absPath(path))
       pkt.notifyOnChange(msgId, true)
@@ -521,13 +274,12 @@ class RegistryApi(cxnHolder: LabradConnectionHolder, client: RegistryClientApi) 
       try {
         watches -= path
 
-        val reg = cxnHolder.cxn.registry
+        val reg = cxn.registry
         val pkt = reg.packet(watch.context)
         pkt.notifyOnChange(watch.msgId, false)
         Await.result(pkt.send(), 10.seconds)
 
-        val cxn = cxnHolder.cxn.get
-        cxn.removeMessageListener(watch.listener)
+        cxn.get.removeMessageListener(watch.listener)
       } catch {
         case e: Exception =>
           log.error(s"unable to unwatch path $path", e)

--- a/server/src/main/scala/org/labrad/browser/VaultController.scala
+++ b/server/src/main/scala/org/labrad/browser/VaultController.scala
@@ -87,14 +87,14 @@ object VaultApi {
   }
 }
 
-class VaultApi(cxnHolder: LabradConnectionHolder)(implicit ec: ExecutionContext) {
+class VaultApi(cxn: LabradConnection)(implicit ec: ExecutionContext) {
 
   import VaultApi._
 
   // vault utility functions
 
   private def startPacket(path: Seq[String]) = {
-    val dv = new VaultServerProxy(cxnHolder.cxn.get)
+    val dv = new VaultServerProxy(cxn.get)
     val pkt = dv.packet()
     pkt.cd(absPath(path))
     pkt

--- a/server/src/main/scala/org/labrad/browser/WebsocketController.scala
+++ b/server/src/main/scala/org/labrad/browser/WebsocketController.scala
@@ -1,46 +1,51 @@
 package org.labrad.browser
 
-import akka.actor.{Actor, ActorRef, Props}
-import com.fasterxml.jackson.databind.ObjectMapper
 import javax.inject._
 import net.maffoo.jsonquote.play._
-import org.labrad.browser.common.message.{Message => ClientMessage, _}
-import org.labrad.browser.jsonrpc.{Message => JsonRpcMessage, _}
+import org.labrad.browser.jsonrpc._
 import org.labrad.data._
 import org.labrad.util.Logging
 import play.api.Application
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json.{Json, JsValue}
 import play.api.mvc.{Handler => _, _}
-import scala.collection.JavaConverters._
 import scala.collection.mutable
-import scala.concurrent.{Await, Future}
+import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.reflect.ClassTag
 
 
-class JsonRpcController @Inject() (cxnHolder: LabradConnectionHolder)(implicit app: Application) extends Controller {
+class JsonRpcController @Inject() ()(implicit app: Application) extends Controller {
 
   def socket = WebSocket.acceptWithActor[String, String] { request => out =>
     val backend = new Backend {
-      var client: Endpoint = null
+      var cxn: LabradConnection = null
       var datavaultApi: VaultApi = null
       var managerApi: ManagerApi = null
       var registryApi: RegistryApi = null
       var handlers: Map[String, Handler] = null
 
-      def connect(endpoint: Endpoint): Unit = {
-        client = endpoint
-        datavaultApi = new VaultApi(cxnHolder)
-        val registryClientApi = JsonRpc.makeProxy(classOf[RegistryClientApi], client)
-        registryApi = new RegistryApi(cxnHolder, registryClientApi)
+      def connect(client: Endpoint): Unit = {
+        // proxies to make calls and send notifications to the client
+        val labradClient = JsonRpc.makeProxy(classOf[LabradClientApi], client)
+        val nodeClient = JsonRpc.makeProxy(classOf[NodeClientApi], client)
+        val registryClient = JsonRpc.makeProxy(classOf[RegistryClientApi], client)
+
+        // connect to labrad (and reconnect if connection is lost)
+        cxn = new LabradConnection(labradClient, nodeClient)
+
+        // api implementations for incoming calls and notifications
+        datavaultApi = new VaultApi(cxn)
+        managerApi = new ManagerApi(cxn)
+        registryApi = new RegistryApi(cxn, registryClient)
+
+        // create handlers that will parse the incoming jsonrpc
         handlers = JsonRpc.makeHandlers(datavaultApi) ++
                    JsonRpc.makeHandlers(managerApi) ++
                    JsonRpc.makeHandlers(registryApi)
       }
 
-      def disconnect(endpoint: Endpoint): Unit = {
-        client = null
+      def disconnect(client: Endpoint): Unit = {
+        cxn.close()
         datavaultApi = null
         managerApi = null
         registryApi = null
@@ -61,125 +66,3 @@ class JsonRpcController @Inject() (cxnHolder: LabradConnectionHolder)(implicit a
     JsonRpcTransport.props(out, backend)
   }
 }
-
-
-class WebSocketController @Inject() (implicit app: Application) extends Controller with Logging {
-  def socket = WebSocket.acceptWithActor[String, String] { request => out =>
-    LabradSocketActor.props(out)
-  }
-}
-
-trait Sink {
-  def send[M <: ClientMessage](msg: M)(implicit tag: ClassTag[M]): Unit
-}
-
-object LabradSocketActor {
-  def props(out: ActorRef) = Props(new LabradSocketActor(out))
-}
-
-class LabradSocketActor(out: ActorRef) extends Actor with Logging {
-
-  private val mapper = new ObjectMapper
-  private var nextMessageId: Int = 1
-  private var cxn: LabradConnection = _
-
-  type Listener = PartialFunction[Message, Unit]
-  case class Watch(context: Context, msgId: Long, listener: Listener)
-  private val watches = mutable.Map.empty[Seq[String], Watch]
-
-  override def preStart(): Unit = {
-    cxn = new LabradConnection(sinkOpt = Some(new Sink {
-      def send[M <: ClientMessage](msg: M)(implicit tag: ClassTag[M]): Unit = {
-        LabradSocketActor.this.send(msg)
-      }
-    }))
-  }
-
-  override def postStop(): Unit = {
-    if (cxn != null) {
-      cxn.close()
-      cxn = null
-    }
-  }
-
-  def receive = {
-    case "PING" => out ! "PONG"
-    case "PONG" =>
-    case msg: String =>
-      import play.api.libs.json._
-      val json = Json.parse(msg)
-      (json \ "type").as[String] match {
-        case "watch" =>
-          val path = (json \ "payload" \ "path").as[Seq[String]]
-          watch(path)
-
-        case "unwatch" =>
-          val path = (json \ "payload" \ "path").as[Seq[String]]
-          unwatch(path)
-      }
-
-  }
-
-  private def send[M <: ClientMessage](msg: M)(implicit tag: ClassTag[M]): Unit = {
-    val className = tag.runtimeClass.getName
-    val payload = Json.parse(mapper.writeValueAsString(msg))
-    val message = json"""{
-      type: $className,
-      payload: $payload
-    }"""
-    out ! message.toString
-  }
-
-  private def watch(path: Seq[String]): Unit = {
-    watches.get(path) match {
-      case Some(ctx) => // already watching this path
-      case None =>
-        try {
-          val cxn = this.cxn.get
-          val ctx = cxn.newContext
-          val msgId = ctx.low
-          nextMessageId += 1
-          val listener: Listener = {
-            case msg @ Message(src, `ctx`, `msgId`, Cluster(Str(name), Bool(isDir), Bool(addOrChange))) =>
-              if (isDir) {
-                send(new RegistryDirMessage(path.asJava, name, addOrChange))
-              } else {
-                send(new RegistryKeyMessage(path.asJava, name, addOrChange))
-              }
-          }
-          cxn.addMessageListener(listener)
-
-          val reg = this.cxn.registry
-          val pkt = reg.packet(ctx)
-          pkt.cd(RegistryController.absPath(path))
-          pkt.notifyOnChange(msgId, true)
-          Await.result(pkt.send(), 10.seconds)
-
-          watches += path -> Watch(ctx, msgId, listener)
-
-        } catch {
-          case e: Exception =>
-            log.error(s"unable to watch path $path", e)
-        }
-    }
-  }
-
-  private def unwatch(path: Seq[String]): Unit = {
-    for (watch <- watches.get(path)) {
-      try {
-        watches -= path
-        val cxn = this.cxn.get
-        val reg = this.cxn.registry
-        val pkt = reg.packet(watch.context)
-        pkt.notifyOnChange(watch.msgId, false)
-        Await.result(pkt.send(), 10.seconds)
-
-        cxn.removeMessageListener(watch.listener)
-      } catch {
-        case e: Exception =>
-          log.error(s"unable to unwatch path $path", e)
-      }
-    }
-  }
-}
-

--- a/server/src/main/scala/org/labrad/browser/WebsocketController.scala
+++ b/server/src/main/scala/org/labrad/browser/WebsocketController.scala
@@ -26,9 +26,11 @@ class JsonRpcController @Inject() (cxnHolder: LabradConnectionHolder)(implicit a
       var client: Endpoint = null
       var registryClientApi: RegistryClientApi = null
 
+      val datavaultApi = new VaultApi(cxnHolder)
       val managerApi = new ManagerApi(cxnHolder)
       val registryApi = new RegistryApi(cxnHolder)
-      val handlers = JsonRpc.makeHandlers(managerApi) ++
+      val handlers = JsonRpc.makeHandlers(datavaultApi) ++
+                     JsonRpc.makeHandlers(managerApi) ++
                      JsonRpc.makeHandlers(registryApi)
 
       def connect(endpoint: Endpoint): Unit = {


### PR DESCRIPTION
This touches a lot of code, but in the end I think it will be a big simplification. We remove all the http interfaces and leave just the jsonrpc interfaces, which will mean less code duplication, especially on the server side. Also fixes how server->client calls and notifications work from the server perspective; still need to do some work to wire this up nicely on the client side, but for now they're logged and least so we can verify that they're coming through as expected.
