### PR TITLE
Remove hardcoded websocket url and allow overriding in dev mode.

### DIFF
--- a/client-js/app/index.html
+++ b/client-js/app/index.html
@@ -33,6 +33,7 @@
   <link rel="stylesheet" href="/styles/main.css">
   <script src="/bower_components/webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="/elements/elements.html">
+  <!-- PROD_MODE -->
 </head>
 
 <body unresolved class="fullbleed layout vertical">

--- a/client-js/app/scripts/app.ts
+++ b/client-js/app/scripts/app.ts
@@ -25,7 +25,22 @@ window.addEventListener('WebComponentsReady', function() {
     page(e.detail.path);
   });
 
-  var socket = new rpc.JsonRpcSocket('ws://localhost:9000/api/socket');
+  // Construct a websocket url relative to this page based on window.location
+  // Note that window.location.protocol includes a trailing colon, but
+  // window.location.port does not include a leading colon.
+  function relativeWebSocketUrl(): string {
+    var loc = window.location;
+    var protocol = loc.protocol === 'https:' ? 'wss:' : 'ws:';
+    var port = loc.port === '' ? '' : `:${loc.port}`;
+    return `${protocol}//${loc.hostname}${port}`;
+  }
+
+  // Get the url for the api backend websocket connection.
+  // If the apiHost variable has been set globally, use that,
+  // otherwise construct a url relative to the page host.
+  var apiUrl = (window['apiHost'] || relativeWebSocketUrl()) + "/api/socket";
+
+  var socket = new rpc.JsonRpcSocket(apiUrl);
   var mgr = new manager.ManagerServiceJsonRpc(socket);
   var reg = new registry.RegistryServiceJsonRpc(socket);
   var dv = new datavault.DataVaultService(socket);

--- a/client-js/gulpfile.js
+++ b/client-js/gulpfile.js
@@ -178,6 +178,15 @@ gulp.task('html', function () {
     .pipe($.size({title: 'html'}));
 });
 
+// Inject an alternate url for connecting to the api backend in dev mode.
+gulp.task('websocket-url', function () {
+  return gulp.src(['app/index.html'])
+    .pipe($.replace('<!-- PROD_MODE -->',
+                    '<script type="text/javascript">window.apiHost = "ws://localhost:9000";</script>'))
+    .pipe(gulp.dest('.tmp'))
+    .pipe($.size({title: 'websocket-url'}));
+});
+
 // Vulcanize imports
 gulp.task('vulcanize', function () {
   var DEST_DIR = 'dist/elements';
@@ -213,7 +222,7 @@ gulp.task('precache', function (callback) {
 gulp.task('clean', del.bind(null, ['.tmp', 'dist']));
 
 // Watch Files For Changes & Reload
-gulp.task('serve', ['webpack', 'styles', 'elements', 'images'], function () {
+gulp.task('serve', ['websocket-url', 'webpack', 'styles', 'elements', 'images'], function () {
   var folder = path.resolve(__dirname, ".");
   browserSync({
     notify: false,

--- a/client-js/gulpfile.js
+++ b/client-js/gulpfile.js
@@ -32,20 +32,6 @@ var AUTOPREFIXER_BROWSERS = [
   'bb >= 10'
 ];
 
-
-// Generate the app.d.ts references file dynamically from all application *.ts files.
-// gulp.task('gen-ts-refs', function () {
-//     var target = gulp.src(config.appTypeScriptReferences);
-//     var sources = gulp.src([config.allTypeScript], {read: false});
-//     return target.pipe(inject(sources, {
-//         starttag: '//{',
-//         endtag: '//}',
-//         transform: function (filepath) {
-//             return '/// <reference path="../..' + filepath + '" />';
-//         }
-//     })).pipe(gulp.dest(config.typings));
-// });
-
 // Lint all custom TypeScript files.
 gulp.task('tslint', function () {
   return gulp.src('app/**/*.ts')
@@ -78,25 +64,6 @@ gulp.task("webpack", function(callback) {
     }));
     callback();
   });
-});
-
-// TODO: get this working; figure out what to do between this and browserSync
-gulp.task("webpack-dev-server", function(callback) {
-    // Start a webpack-dev-server
-    var compiler = webpack({
-        // configuration
-    });
-
-    new WebpackDevServer(compiler, {
-        // server and middleware options
-    }).listen(8080, "localhost", function(err) {
-        if(err) throw new gutil.PluginError("webpack-dev-server", err);
-        // Server listening
-        gutil.log("[webpack-dev-server]", "http://localhost:8080/webpack-dev-server/index.html");
-
-        // keep the server alive or continue?
-        // callback();
-    });
 });
 
 var styleTask = function (stylesPath, srcs) {


### PR DESCRIPTION
When we deploy to production, the url for the websocket connection should be relative to the page (the host and port from which we loaded the html). I dev mode, we insert a script to set a global variable to override this so that the api connection goes to the scala server running on port 9000, instead of the js dev server running on port 3000.
