### PR TITLE
Add client-side support for node service api.

### DIFF
--- a/client-js/app/scripts/app.ts
+++ b/client-js/app/scripts/app.ts
@@ -5,6 +5,7 @@ import page = require("page");
 import manager = require("./manager");
 import registry = require("./registry");
 import datavault = require("./datavault");
+import nodeApi = require("./node");
 import rpc = require("./rpc");
 
 // autobinding template which is the main ui container
@@ -44,6 +45,7 @@ window.addEventListener('WebComponentsReady', function() {
   var mgr = new manager.ManagerServiceJsonRpc(socket);
   var reg = new registry.RegistryServiceJsonRpc(socket);
   var dv = new datavault.DataVaultService(socket);
+  var node = new nodeApi.NodeService(socket);
 
   function pathStr(path: Array<string>, dir?: string): string {
     var url = '';

--- a/client-js/app/scripts/node.ts
+++ b/client-js/app/scripts/node.ts
@@ -1,0 +1,55 @@
+import promise = require('es6-promise');
+
+import rpc = require("./rpc");
+
+var Promise = promise.Promise;
+
+export interface ServerStatus {
+  name: string;
+  description: string;
+  version: string;
+  instanceName: string;
+  environmentVars: Array<string>;
+  instances: Array<string>;
+}
+
+export interface NodeStatus {
+  name: string;
+  servers: Array<ServerStatus>;
+}
+
+export interface NodeApi {
+  allNodes(): Promise<Array<NodeStatus>>;
+
+  refreshNode(node: string): Promise<string>;
+
+  restartServer(params: {node: string; server: string}): Promise<void>;
+  startServer(params: {node: string; server: string}): Promise<void>;
+  stopServer(params: {node: string; server: string}): Promise<void>;
+}
+
+export class NodeService extends rpc.RpcService implements NodeApi {
+
+  constructor(socket: rpc.JsonRpcSocket) {
+    super(socket, "org.labrad.node.");
+  }
+
+  allNodes(): Promise<Array<NodeStatus>> {
+    return this.call<Array<NodeStatus>>('allNodes', []);
+  }
+
+  refreshNode(node: string): Promise<string> {
+    return this.call<string>('refreshNode', [node]);
+  }
+
+  restartServer(params: {node: string; server: string}): Promise<void> {
+    return this.call<void>('restartServer', params);
+  }
+  startServer(params: {node: string; server: string}): Promise<void> {
+    return this.call<void>('startServer', params);
+  }
+  stopServer(params: {node: string; server: string}): Promise<void> {
+    return this.call<void>('stopServer', params);
+  }
+}
+

--- a/server/src/main/scala/org/labrad/browser/ApiBackend.scala
+++ b/server/src/main/scala/org/labrad/browser/ApiBackend.scala
@@ -14,6 +14,7 @@ class ApiBackend(implicit ec: ExecutionContext) extends Backend {
   private var cxn: LabradConnection = null
   private var datavaultApi: VaultApi = null
   private var managerApi: ManagerApi = null
+  private var nodeApi: NodeApi = null
   private var registryApi: RegistryApi = null
   private var routes: Map[String, Handler] = null
 
@@ -55,6 +56,12 @@ class ApiBackend(implicit ec: ExecutionContext) extends Backend {
       CALL                    .connection_close            .connectionClose
       CALL                    .server_info                 .serverInfo
 
+      CALL  org.labrad.node.allNodes       nodeApi.allNodes
+      CALL                 .refreshNode           .refreshNode
+      CALL                 .restartServer         .restartServer
+      CALL                 .startServer           .startServer
+      CALL                 .stopServer            .stopServer
+
       CALL  org.labrad.registry.dir        registryApi.dir
       CALL                     .set                   .set
       CALL                     .del                   .del
@@ -75,6 +82,7 @@ class ApiBackend(implicit ec: ExecutionContext) extends Backend {
     cxn.close()
     datavaultApi = null
     managerApi = null
+    nodeApi = null
     registryApi = null
     routes = null
   }


### PR DESCRIPTION
The node api is not being used for anything quite yet, just wanted to get the client-side stub for it in place, then I'll work on the ui for controlling the nodes.
