### PR TITLE
Add UI for controlling node servers

### DIFF
--- a/client-js/app/elements/elements.html
+++ b/client-js/app/elements/elements.html
@@ -34,6 +34,7 @@
 <link rel="import" href="labrad-grapher.html">
 <link rel="import" href="labrad-grapher-dataset.html">
 <link rel="import" href="labrad-manager.html">
+<link rel="import" href="labrad-nodes.html">
 <link rel="import" href="labrad-registry.html">
 <link rel="import" href="dir-item.html">
 <link rel="import" href="labrad-server.html">

--- a/client-js/app/elements/labrad-nodes.html
+++ b/client-js/app/elements/labrad-nodes.html
@@ -1,0 +1,131 @@
+<link rel="import" href="../bower_components/iron-icons/av-icons.html">
+<link rel="import" href="../bower_components/paper-icon-button/paper-icon-button.html">
+<link rel="import" href="../bower_components/paper-spinner/paper-spinner.html">
+<link rel="import" href="app-link.html">
+
+<dom-module id="labrad-instance-controller">
+  <style>
+    .divider {
+      font-weight: bold;
+    }
+    td {
+      padding: 2px 5px 2px 5px;
+    }
+    paper-icon-button {
+      padding: 0px;
+    }
+    paper-spinner {
+      width: 18px;
+      height: 18px;
+      top: 5px;
+    }
+  </style>
+  <template>
+    <div>
+      <!-- states: stopped, starting, started, stopping -->
+      <!-- <span>{{status}}</span> -->
+      <a is="app-link" path="{{serverUrl}}" href="{{serverUrl}}">
+        <paper-icon-button id="info" icon="info"></paper-icon-button></a>
+
+      <span hidden$="{{!active}}">
+        <paper-spinner active></paper-spinner>
+      </span>
+
+      <span hidden$="{{active}}">
+        <paper-icon-button id="start" icon="av:play-arrow"></paper-icon-button>
+        <paper-icon-button id="stop" icon="av:stop"></paper-icon-button>
+        <paper-icon-button id="restart" icon="av:replay"></paper-icon-button>
+      </span>
+    </div>
+  </template>
+</dom-module>
+
+<dom-module id="labrad-node-controller">
+  <style>
+    paper-icon-button {
+      padding: 0px;
+    }
+    paper-spinner {
+      width: 18px;
+      height: 18px;
+      top: 5px;
+    }
+  </style>
+  <template>
+    <span>{{name}}</span>
+
+    <span hidden$="{{!active}}">
+      <paper-spinner active></paper-spinner>
+    </span>
+
+    <span hidden$="{{active}}">
+      <paper-icon-button id="refresh" icon="av:replay"></paper-icon-button>
+    </span>
+  </template>
+</dom-module>
+
+<dom-module id="labrad-nodes">
+  <style>
+    :host {
+      display: block;
+    }
+  </style>
+  <template>
+    <div>
+      <table>
+        <thead>
+          <th>Global Servers</th>
+          <template is="dom-repeat" items="{{nodeNames}}" as="node">
+            <th><labrad-node-controller api={{api}} name={{node}}></labrad-node-controller></th>
+          </template>
+        </thead>
+        <tbody>
+          <template is="dom-repeat" items="{{globalServers}}" as="server">
+            <tr>
+              <td>{{server.name}}</td>
+              <template is="dom-repeat" items="{{server.nodes}}" as="node">
+                <td>
+                  <template is="dom-if" if="{{node.exists}}">
+                    <labrad-instance-controller
+                      api={{api}}
+                      local
+                      name={{server.name}}
+                      instance-name={{node.instanceName}}
+                      node={{node.name}}
+                      status={{node.status}} />
+                  </template>
+                </td>
+              </template>
+            </tr>
+          </template>
+        </tbody>
+
+        <thead>
+          <th>Local Servers</th>
+          <template is="dom-repeat" items="{{nodeNames}}">
+            <th></th>
+          </template>
+        </thead>
+        <tbody>
+          <template is="dom-repeat" items="{{localServers}}" as="server">
+            <tr>
+              <td>{{server.name}}</td>
+              <template is="dom-repeat" items="{{server.nodes}}" as="node">
+                <td>
+                  <template is="dom-if" if="{{node.exists}}">
+                    <labrad-instance-controller
+                      api={{api}}
+                      name={{server.name}}
+                      instance-name={{node.instanceName}}
+                      node={{node.name}}
+                      status={{node.status}} />
+                  </template>
+                </td>
+              </template>
+            </tr>
+          </template>
+        </tbody>
+      </table>
+    </div>
+  </template>
+</dom-module>

--- a/client-js/app/elements/labrad-nodes.ts
+++ b/client-js/app/elements/labrad-nodes.ts
@@ -1,0 +1,330 @@
+import {Lifetime} from '../scripts/lifetime';
+import {ManagerApi, ServerConnectMessage, ServerDisconnectMessage} from '../scripts/manager';
+import {NodeApi, NodeStatus, ServerStatus, ServerStatusMessage} from '../scripts/node';
+
+@component('labrad-instance-controller')
+export class LabradInstanceController extends polymer.Base {
+  @property()
+  name: string;
+
+  @property()
+  instanceName: string;
+
+  @property()
+  node: string;
+
+  @property({type: Boolean})
+  local: boolean;
+
+  @property({type: Boolean})
+  runningElsewhere: boolean;
+
+  @property()
+  status: string;
+
+  @property({type: Boolean, value: false})
+  active: boolean;
+
+  @property()
+  api: NodeApi;
+
+  @computed()
+  serverUrl(instanceName: string): string {
+    return `/server/${encodeURIComponent(instanceName)}`
+  }
+
+  ready() {
+    this.updateButtonState(this.status);
+  }
+
+  @observe('status')
+  statusChanged(newStatus: string, oldStatus: string) {
+    this.updateButtonState(newStatus);
+  }
+
+  @listen('start.click')
+  doStart() {
+    console.log(`start: server='${this.name}', node='${this.node}'`);
+    this.api.startServer({node: this.node, server: this.name});
+  }
+
+  @listen('stop.click')
+  doStop() {
+    console.log(`stop: server='${this.name}', node='${this.node}'`);
+    this.api.stopServer({node: this.node, server: this.instanceName});
+  }
+
+  @listen('restart.click')
+  doRestart() {
+    console.log(`restart: server='${this.name}', node='${this.node}'`);
+    this.api.restartServer({node: this.node, server: this.instanceName});
+  }
+
+  statusChange(msg: ServerStatusMessage): void {
+    if (this.name === msg.server) {
+      if (this.node === msg.node) {
+        this.status = msg.status;
+        this.instanceName = msg.instance;
+      } else if (this.local) {
+        switch (msg.status) {
+          case 'STOPPED': this.updateButtonState(this.status); break;
+          case 'STARTING': this.updateButtonState('RUNNING_ELSEWHERE'); break;
+          case 'STARTED': this.updateButtonState('RUNNING_ELSEWHERE'); break;
+          case 'STOPPPING': this.updateButtonState('RUNNING_ELSEWHERE'); break;
+        }
+      }
+    }
+  }
+
+  /**
+   * Manage the enabled/disabled state of control buttons depending on the
+   * state of this particular server instance.
+   */
+  updateButtonState(status: string) {
+    var self = this,
+        options = {info: false, start: false, stop: false, restart: false};
+    switch (status) {
+      case 'STOPPED': this.active = false; options.start = true; break;
+      case 'STARTING': this.active = true; break;
+      case 'STARTED': this.active = false; options.info = true; options.stop = true; options.restart = true; break;
+      case 'STOPPING': this.active = true; break;
+      default: break;
+    }
+    function updateButton(name: string) {
+      var button = self.$[name];
+      if (options[name]) {
+        button.removeAttribute('disabled');
+      } else {
+        button.setAttribute('disabled', 'disabled');
+      }
+    }
+    updateButton('info');
+    updateButton('start');
+    updateButton('stop');
+    updateButton('restart');
+  }
+}
+
+@component('labrad-node-controller')
+export class LabradNodeController extends polymer.Base {
+  @property({type: Object})
+  api: NodeApi;
+
+  @property()
+  name: string;
+
+  @property({type: Boolean, value: false})
+  active: boolean;
+
+  @listen('refresh.click')
+  onRefresh() {
+    var self = this;
+    this.active = true;
+    this.api.refreshNode(this.name).then(
+      (result) => { self.active = false; },
+      (error) => { self.active = false; }
+    );
+  }
+}
+
+@component('labrad-nodes')
+export class LabradNodes extends polymer.Base {
+  @property({type: Array, notify: true})
+  info: Array<NodeStatus>;
+
+  @property({type: Object})
+  api: NodeApi;
+
+  @property({type: Object})
+  managerApi: ManagerApi;
+
+  @property({type: Number, value: 0})
+  kick: number;
+
+  private lifetime = new Lifetime();
+  // Used to manage cleanup operations that should be performed when this
+  // component is destroyed. We register all such cleanup operations (such as
+  // Observable callback removals) with this lifetime, and then close it when
+  // the component is detached.
+
+  /**
+   * Polymer lifecyle callback invoked when this component is detached from the
+   * DOM and ready to be cleaned up.
+   */
+  detached() {
+    this.lifetime.close();
+  }
+
+  defined(x: any): boolean {
+    return (typeof x !== 'undefined') && (x !== null);
+  }
+
+  // Listeners called on api object properties when they get set. This is
+  // necessary because these properties are set asynchronously sometime after
+  // the component is constructed, so we cannot access the values when the
+  // ready() lifecycle method is invoked, for example.
+
+  @observe('api')
+  apiChanged(newApi: NodeApi, oldApi: NodeApi) {
+    console.log('apiChanged', newApi, oldApi);
+    if (this.defined(newApi)) {
+      newApi.nodeStatus.add(this.onNodeStatus.bind(this), this.lifetime);
+      newApi.serverStatus.add(this.onServerStatus.bind(this), this.lifetime);
+    }
+  }
+
+  @observe('managerApi')
+  managerChanged(newManager: ManagerApi, oldManager: ManagerApi) {
+    console.log('managerChanged', newManager, oldManager);
+    if (this.defined(newManager)) {
+      newManager.serverDisconnected.add(this.onServerDisconnected.bind(this), this.lifetime);
+    }
+  }
+
+  // callbacks invoked when we receive remote messages
+
+  onNodeStatus(msg: NodeStatus): void {
+    console.log('onNodeStatus', msg);
+    // we need to splice this new NodeStatus into the current info array.
+    // first, check to see whether we already have status for this node.
+    var idx = this._nodeIndex(msg.name);
+
+    if (idx === -1) {
+      this.push('info', msg);
+    } else {
+      this.splice('info', idx, 1, msg);
+    }
+    this.kick++;
+  }
+
+  onServerDisconnected(msg: ServerDisconnectMessage): void {
+    console.log('server disconnected:', msg.name);
+    var idx = this._nodeIndex(msg.name);
+
+    if (idx >= 0) {
+      this.splice('info', idx, 1);
+      this.kick++;
+    }
+  }
+
+  onServerStatus(msg: ServerStatusMessage): void {
+    console.log('onServerStatus', msg);
+    var instances = Polymer.dom(this.root).querySelectorAll('labrad-instance-controller');
+    for (var i = 0; i < instances.length; i++) {
+      var instance = <any>instances[i];
+      if (instance.name === msg.server) {
+        // Send the server status to all instance controllers, even if they are
+        // on other nodes. This is because for global servers we must lock out
+        // the controls if a server is running _anywhere_.
+        instance.statusChange(msg);
+      }
+    }
+  }
+
+
+  /**
+   * Find the index in the node info list of a node with the given name.
+   *
+   * If no such node is found, returns -1.
+   */
+  private _nodeIndex(name: string): number {
+    var idx = -1;
+    for (var i = 0; i < this.info.length; i++) {
+      if (this.info[i].name === name) {
+        idx = i;
+        break;
+      }
+    }
+    return idx;
+  }
+
+  private _nodeNames(info: Array<NodeStatus>): Array<string> {
+    var names = info.map((n) => n.name);
+    names.sort();
+    return names;
+  }
+
+  private _serverNames(info: Array<NodeStatus>, options: {global: boolean}): Array<string> {
+    var nameSet = new Set<string>();
+    for (let nodeInfo of info) {
+      for (let server of nodeInfo.servers) {
+        var isGlobal = server.environmentVars.length === 0;
+        if (isGlobal === options.global) {
+          nameSet.add(server.name);
+        }
+      }
+    }
+    var names = Array.from(nameSet.values());
+    names.sort();
+    return names;
+  }
+
+  private _statusMap(info: Array<NodeStatus>): Map<string, Map<string, ServerStatus>> {
+    var statusMap = new Map<string, Map<string, ServerStatus>>();
+    for (let nodeStatus of info) {
+      var serverMap = new Map<string, ServerStatus>();
+      for (let serverStatus of nodeStatus.servers) {
+        serverMap.set(serverStatus.name, serverStatus);
+      }
+      statusMap.set(nodeStatus.name, serverMap);
+    }
+    return statusMap;
+  }
+
+  @computed()
+  nodeNames(info: Array<NodeStatus>, kick: number): Array<string> {
+    return this._nodeNames(info)
+  }
+
+  @computed()
+  globalServers(info: Array<NodeStatus>, kick: number): Array<{name: string, nodes: Array<{name: string, exists: boolean, status?: string, instanceName?: string}>}> {
+    var nodeNames = this._nodeNames(info);
+    var serverNames = this._serverNames(info, {global: true});
+    var statusMap = this._statusMap(info);
+
+    return serverNames.map((server) => {
+      return {
+        name: server,
+        nodes: nodeNames.map((node) => {
+          var status = statusMap.get(node).get(server);
+          if (typeof status === 'undefined') {
+            return {name: node, exists: false};
+          } else {
+            return {
+              name: node,
+              exists: true,
+              status: status.instances.length > 0 ? 'STARTED' : 'STOPPED',
+              instanceName: status.instances[0] || server
+            }
+          }
+        })
+      };
+    });
+  }
+
+  @computed()
+  localServers(info: Array<NodeStatus>, kick: number): Array<{name: string, nodes: Array<{name: string, exists: boolean, status?: string, instanceName?: string}>}> {
+    var nodeNames = this._nodeNames(info);
+    var serverNames = this._serverNames(info, {global: false});
+    var statusMap = this._statusMap(info);
+
+    return serverNames.map((server) => {
+      return {
+        name: server,
+        nodes: nodeNames.map((node) => {
+          var status = statusMap.get(node).get(server);
+          if (typeof status === 'undefined') {
+            return {name: node, exists: false};
+          } else {
+            return {
+              name: node,
+              exists: true,
+              status: status.instances.length > 0 ? 'STARTED' : 'STOPPED',
+              instanceName: status.instances[0] || server
+            }
+          }
+        })
+      };
+    });
+  }
+}

--- a/client-js/app/index.html
+++ b/client-js/app/index.html
@@ -115,7 +115,11 @@
 
           <section data-route="nodes">
             <paper-material elevation="0">
-              <h1>Nodes!!</h1>
+              <labrad-nodes
+                  info={{nodesInfo}}
+                  api={{nodeApi}}
+                  manager-api={{managerApi}}>
+              </labrad-nodes>
             </paper-material>
           </section>
 

--- a/client-js/app/scripts/app.ts
+++ b/client-js/app/scripts/app.ts
@@ -8,6 +8,7 @@ import * as datavault from "./datavault";
 import * as nodeApi from "./node";
 import * as rpc from "./rpc";
 
+import {LabradNodes, LabradInstanceController, LabradNodeController} from "../elements/labrad-nodes";
 import {LabradRegistry} from "../elements/labrad-registry";
 
 // autobinding template which is the main ui container
@@ -24,6 +25,9 @@ app.onMenuSelect = function() {
 window.addEventListener('WebComponentsReady', function() {
   // register our custom elements with polymer
   LabradRegistry.register();
+  LabradNodes.register();
+  LabradInstanceController.register();
+  LabradNodeController.register();
 
   var body = document.querySelector('body');
   body.removeAttribute('unresolved');
@@ -177,7 +181,12 @@ window.addEventListener('WebComponentsReady', function() {
   });
 
   page('/nodes', () => {
-    app.route = 'nodes';
+    node.allNodes().then((nodesInfo) => {
+      app.route = 'nodes';
+      app.nodesInfo = nodesInfo;
+      app.nodeApi = node;
+      app.managerApi = mgr;
+    });
   });
 
   page('/registry', () => {

--- a/client-js/app/scripts/lifetime.ts
+++ b/client-js/app/scripts/lifetime.ts
@@ -1,0 +1,37 @@
+/**
+ * A container for cleanup operations to be executed at a later time.
+ *
+ * You can think of a Lifetime as a way to emulate C++ destructors. We create
+ * a Lifetime and then call defer, passing in cleanup functions that we want
+ * to be run at the end of that lifetime. When the lifetime's close() method is
+ * called, all those cleanup callbacks will be run, in reverse order from how
+ * they were added.
+ */
+export class Lifetime {
+  private closed = false;
+  private callbacks = new Array<() => void>();
+
+  /**
+   * Schedule the given function to be run when this Lifetime is closed.
+   *
+   * If the lifetime is already closed, this raises an error.
+   */
+  defer(callback: () => void) {
+    if (this.closed) throw new Error('lifetime already closed');
+    this.callbacks.unshift(callback);
+    // unshift puts the callback at the front of the list, since we want
+    // to run callbacks in LIFO order.
+  }
+
+  /**
+   * Close this lifetime, executing all deferred callbacks.
+   *
+   * If the lifetime is already closed, this raises an error.
+   */
+  close() {
+    if (this.closed) throw new Error('lifetime already closed');
+    for (let callback of this.callbacks) {
+      callback();
+    }
+  }
+}

--- a/client-js/app/scripts/manager.ts
+++ b/client-js/app/scripts/manager.ts
@@ -1,3 +1,4 @@
+import {Observable} from "./observable";
 import * as rpc from "./rpc";
 
 export interface ConnectionInfo {
@@ -32,16 +33,35 @@ export interface ServerInfo {
   settings: Array<SettingInfo>;
 }
 
+export interface LabradConnectMessage { host: string; }
+export interface LabradDisconnectMessage { host: string; }
+export interface ServerConnectMessage { name: string; }
+export interface ServerDisconnectMessage { name: string; }
+
 export interface ManagerApi {
   connections(): Promise<Array<ConnectionInfo>>;
   connectionClose(id: number): Promise<string>;
   serverInfo(name: String): Promise<ServerInfo>;
+
+  connected: Observable<LabradConnectMessage>;
+  disconnected: Observable<LabradDisconnectMessage>;
+  serverConnected: Observable<ServerConnectMessage>;
+  serverDisconnected: Observable<ServerDisconnectMessage>;
 }
 
 export class ManagerServiceJsonRpc extends rpc.RpcService implements ManagerApi {
 
+  connected = new Observable<LabradConnectMessage>();
+  disconnected = new Observable<LabradDisconnectMessage>();
+  serverConnected = new Observable<ServerConnectMessage>();
+  serverDisconnected = new Observable<ServerDisconnectMessage>();
+
   constructor(socket: rpc.JsonRpcSocket) {
     super(socket, "org.labrad.manager.");
+    this.connect("org.labrad.connected", this.connected);
+    this.connect("org.labrad.disconnected", this.disconnected);
+    this.connect("org.labrad.serverConnected", this.serverConnected);
+    this.connect("org.labrad.serverDisconnected", this.serverDisconnected);
   }
 
   connections(): Promise<Array<ConnectionInfo>> {

--- a/client-js/app/scripts/node.ts
+++ b/client-js/app/scripts/node.ts
@@ -1,3 +1,4 @@
+import {Observable} from "./observable";
 import * as rpc from "./rpc";
 
 export interface ServerStatus {
@@ -14,6 +15,13 @@ export interface NodeStatus {
   servers: Array<ServerStatus>;
 }
 
+export interface ServerStatusMessage {
+  node: string;
+  server: string;
+  instance: string;
+  status: string;
+}
+
 export interface NodeApi {
   allNodes(): Promise<Array<NodeStatus>>;
 
@@ -22,12 +30,20 @@ export interface NodeApi {
   restartServer(params: {node: string; server: string}): Promise<void>;
   startServer(params: {node: string; server: string}): Promise<void>;
   stopServer(params: {node: string; server: string}): Promise<void>;
+
+  nodeStatus: Observable<NodeStatus>;
+  serverStatus: Observable<ServerStatusMessage>;
 }
 
 export class NodeService extends rpc.RpcService implements NodeApi {
 
+  nodeStatus = new Observable<NodeStatus>();
+  serverStatus = new Observable<ServerStatusMessage>();
+
   constructor(socket: rpc.JsonRpcSocket) {
-    super(socket, "org.labrad.node.");
+    super(socket, 'org.labrad.node.');
+    this.connect('org.labrad.node.nodeStatus', this.nodeStatus);
+    this.connect('org.labrad.node.serverStatus', this.serverStatus);
   }
 
   allNodes(): Promise<Array<NodeStatus>> {

--- a/client-js/app/scripts/observable.ts
+++ b/client-js/app/scripts/observable.ts
@@ -1,0 +1,43 @@
+import {Lifetime} from './lifetime';
+
+/**
+ * Manages a collection of callbacks that accept messages of type A.
+ *
+ * When the Observable's call() method is invoked with a value of type A,
+ * we schedule all the registered callbacks to be invoked asynchronously.
+ * Observable holds a strong reference to added callbacks which prevents them
+ * from being garbage collected until they have been removed. It is the caller's
+ * responsibility to ensure that callbacks are removed when appropriate to avoid
+ * memory leaks.
+ */
+export class Observable<A> {
+  private callbacks = new Set<(A) => void>();
+
+  /**
+   * Register a callback to be invoked whenever this Observable is called.
+   *
+   * If the optional lifetime parameter is provided, we automatically schedule
+   * the given callback to be removed when the lifetime is closed. Otherwise,
+   * the caller is responsible for removing the callback.
+   */
+  add(callback: (A) => void, lifetime?: Lifetime): (A) => void {
+    this.callbacks.add(callback);
+    if (lifetime) {
+      lifetime.defer((() => this.remove(callback)).bind(this));
+    }
+    return callback;
+  }
+
+  /**
+   * Unregister the given callback.
+   */
+  remove(callback: (A) => void): void {
+    this.callbacks.delete(callback);
+  }
+
+  call(value: A): void {
+    for (let callback of this.callbacks) {
+      window.setTimeout(() => callback(value), 0);
+    }
+  }
+}

--- a/client-js/app/scripts/rpc.ts
+++ b/client-js/app/scripts/rpc.ts
@@ -1,3 +1,5 @@
+import {Observable} from "./observable";
+
 /**
  * Implements the JSON-RPC 2.0 protocol over websockets.
  *
@@ -163,6 +165,8 @@ export class JsonRpcSocket {
   }
 }
 
+
+
 export class RpcService {
   socket: JsonRpcSocket;
   prefix: string;
@@ -174,5 +178,13 @@ export class RpcService {
 
   call<A>(method: string, params: Array<string> | Object): Promise<A> {
     return <Promise<A>> this.socket.call(this.prefix + method, params);
+  }
+
+  notify(method: string, params: Array<string> | Object): void {
+    this.socket.notify(this.prefix + method, params);
+  }
+
+  protected connect<A>(method: string, observable: Observable<A>): void {
+    this.socket.addNotifiable(method, (msg) => observable.call(<A>msg));
   }
 }

--- a/client-js/app/styles/main.css
+++ b/client-js/app/styles/main.css
@@ -4,16 +4,14 @@ body {
   color: #333;
 }
 
-
-
-td,th{
+td, th {
   padding: 12px 24px;
 }
 
 tr {
   width :100%;
 }
-   
+
 th {
   @apply(--paper-font-body1);
   color: var(--secondary-text-color);
@@ -22,15 +20,15 @@ th {
   border-bottom-color: #e5e5e5;
 }
 
-tr :hover    {
+tr :hover {
   color: #616161;
 }
-  
+
 tbody tr:hover {
   background: #fafafa;
 }
 
-table{
+table {
   width: 100%;
 }
 

--- a/client-js/typings/polymer-ts/polymer-ts.d.ts
+++ b/client-js/typings/polymer-ts/polymer-ts.d.ts
@@ -45,7 +45,7 @@ declare module polymer {
         set(path: string, value: any, root?: Object): any;
         setScrollDirection(direction: string, node: HTMLElement): void;
         shift(path: string, value: any): any;
-        splice(path: string, start: number, deleteCount: number): any;
+        splice(path: string, start: number, deleteCount: number, ...items: any[]): any;
         toggleAttribute(name: string, bool: boolean, node?: HTMLElement): void;
         toggleClass(name: string, bool: boolean, node?: HTMLElement): void;
         transform(transform: string, node?: HTMLElement): void;

--- a/server/src/main/scala/org/labrad/browser/ApiBackend.scala
+++ b/server/src/main/scala/org/labrad/browser/ApiBackend.scala
@@ -45,6 +45,7 @@ class ApiBackend(implicit ec: ExecutionContext) extends Backend {
     // api implementations for incoming calls and notifications
     datavaultApi = new VaultApi(cxn)
     managerApi = new ManagerApi(cxn)
+    nodeApi = new NodeApi(cxn)
     registryApi = new RegistryApi(cxn, registryClient)
 
     routes = JsonRpc.routes("""

--- a/server/src/main/scala/org/labrad/browser/NodeApi.scala
+++ b/server/src/main/scala/org/labrad/browser/NodeApi.scala
@@ -31,7 +31,7 @@ class NodeApi(cxn: LabradConnection)(implicit ec: ExecutionContext) extends Logg
       val serverData = await { cxn.manager.servers() }
       val servers = serverData.map { case (id, name) => name }
 
-      val nodes = servers.filter(_.toLowerCase.startsWith("node"))
+      val nodes = servers.filter(_.toLowerCase.startsWith("node "))
       val futures = nodes.map { node =>
         cxn.to(node).call("status").map((node, _))
       }


### PR DESCRIPTION
I've split this into two pieces. In the first commit there's some infrastructure, a class called `Notifiable` that the various api classes create for the messages that they expect from the server which allows adding and removing message handlers for that message type. @DanielSank and I discussed the design of this, but I'd like to get some feedback now that I have a first cut working.

The second commit adds the node ui, meant to replace the old GWT-based version we currently use. To test this out, you'll probably want to spin up a few node servers. In a new shell you can pop into your python virtualenv and then run:

```
twistd --pidfile=foo.pid -n labradnode --name=foo
```

This will start up a node called "node foo" and then you can start a few others with different names. You have to specify a different pidfile name for each copy of the node you run, or else run them in separate directories because the default pid file name will collide. (Note that you're supposed to be able to run the node source file as a script, but the command line parsing is broken; see: https://github.com/labrad/pylabrad/pull/144)

You'll see that the node control UI updates automatically when node servers connect or disconnect, and also when you configure their search paths (you'll want to add your labrad servers directory to the `directories` key in the registry at `["", "Nodes", "<name>"]`.
