### PR TITLE
Creat expandable dialog

### DIFF
--- a/client-js/app/elements/elements.html
+++ b/client-js/app/elements/elements.html
@@ -1,11 +1,13 @@
 <!-- Paper, Iron and Platinum elements -->
 <link rel="import" href="../bower_components/iron-a11y-keys/iron-a11y-keys.html">
 <link rel="import" href="../bower_components/iron-flex-layout/classes/iron-flex-layout.html">
+<link rel="import" href="../bower_components/iron-collapse/iron-collapse.html">
 <link rel="import" href="../bower_components/iron-form/iron-form.html">
 <link rel="import" href="../bower_components/iron-icons/editor-icons.html">
 <link rel="import" href="../bower_components/iron-icons/hardware-icons.html">
 <link rel="import" href="../bower_components/iron-icons/communication-icons.html">
 <link rel="import" href="../bower_components/iron-icons/iron-icons.html">
+<link rel="import" href="../bower_components/iron-input/iron-input.html">
 <link rel="import" href="../bower_components/iron-pages/iron-pages.html">
 <link rel="import" href="../bower_components/iron-selector/iron-selector.html">
 <link rel="import" href="../bower_components/paper-button/paper-button.html">
@@ -16,6 +18,7 @@
 <link rel="import" href="../bower_components/paper-icon-button/paper-icon-button.html">
 <link rel="import" href="../bower_components/paper-input/paper-input.html">
 <link rel="import" href="../bower_components/paper-input/paper-input-container.html">
+<link rel="import" href="../bower_components/paper-input/paper-textarea.html">
 <link rel="import" href="../bower_components/paper-item/paper-item.html">
 <link rel="import" href="../bower_components/paper-item/paper-icon-item.html">
 <link rel="import" href="../bower_components/paper-material/paper-material.html">
@@ -40,3 +43,4 @@
 <link rel="import" href="labrad-server.html">
 <link rel="import" href="menu-button.html">
 <link rel="import" href="selectable-table.html">
+<link rel="import" href="expandable-input.html">

--- a/client-js/app/elements/expandable-input.html
+++ b/client-js/app/elements/expandable-input.html
@@ -7,21 +7,15 @@ event.detail
 
 <dom-module id="expandable-input">
   <style>
-  #long{
-    visibility: hidden;
-    position: absolute;
+  #long {
     width: 80%;
   }
   </style>
   <template >
     <iron-a11y-keys keys="enter" on-keys-pressed="submitForm">
     <!-- TODO remap newline from enter to "ctrl enter" -->
-      <div id="long">
-        <textarea id="input" value="{{value::input}}" rows="[[compRows]]" cols="[[cols]]"></textarea>
-      </div>
-      <div id="short">
-        <paper-item on-click="selectField" id="static" label="{{valueShort}}">{{valueShort}}</paper-item>
-      </div>
+      <paper-textarea id="long" value="{{value::input}}" cols="[[cols]]" no-label-float hidden></paper-textarea>
+      <paper-item id="short" on-click="selectField" label="{{valueShort}}">{{valueShort}}</paper-item>
     </iron-a11y-keys>
   </template>
   <script>
@@ -35,15 +29,10 @@ event.detail
         type: String,
         computed: 'shortenValue(value)'
         },
-        compRows: {
-          //computed number of rows for input
-          type: Number,
-          value: 1
-        },
         cols: {
           //number of characters in text field. Not sized dynamically. For now
           type: Number,
-          value: 100
+          value: 60
         }
     },
     behaviors: [
@@ -54,7 +43,7 @@ event.detail
                ],
     ready: function() {
       //This focus-changed event handles the revealing and hiding of the static field
-     this.addEventListener('focused-changed', this.fieldFocus);
+      this.addEventListener('focused-changed', this.fieldFocus);
     },
     calculateRows: function(value) {
       //calculates the number of rows in the editable input field
@@ -74,23 +63,20 @@ event.detail
       /* When input field brought into focus this enlarges the input field.
       When focus is passed on, this shrinks the field and hides it behind the
       static label */
-      if (this.focused){
-        this.compRows = this.calculateRows(this.value);
-      } else {
-        this.compRows = 1;
-        this.$.short.style.visibility = 'visible';
-        this.$.long.style.visibility = 'hidden';
-      } 
+      if (!this.focused) {
+        this.$.short.hidden = false;
+        this.$.long.hidden = true;
+      }
     },
     submitForm: function() {
       //fires submit so event is picked up by correct Polymer listener
-      this.fire('iron-form-submit', [this.name, this.$.input.value]);
+      this.fire('iron-form-submit', [this.name, this.$.long.$.input.$.textarea.value]);
     },
     selectField: function() {
       //Hides static field to reveal multi-line input which is given focus
-      this.$.short.style.visibility = 'hidden';
-      this.$.long.style.visibility = 'visible';
-      this.$$('textarea').focus();
+      this.$.short.hidden = true;
+      this.$.long.hidden = false;
+      this.$.long.$.input.$.textarea.focus();
     }
   });
   </script>

--- a/client-js/app/elements/expandable-input.html
+++ b/client-js/app/elements/expandable-input.html
@@ -20,19 +20,18 @@ event.detail
         <textarea id="input" value="{{value::input}}" rows="[[compRows]]" cols="[[cols]]"></textarea>
       </div>
       <div id="short">
-        <paper-item on-click="selectField" id="static" label="{{value_short}}">{{value_short}}</paper-item>
+        <paper-item on-click="selectField" id="static" label="{{valueShort}}">{{valueShort}}</paper-item>
       </div>
     </iron-a11y-keys>
   </template>
   <script>
   Polymer({
-    is: "expandable-input",
+    is: 'expandable-input',
     properties: {
       name: {stype: String},
       value: {type: String},
-      value_short: {
-        //holds the shortened value which renders as 'value...' if longer than
-        //cols
+      valueShort: {
+      //holds the shortened value which renders as 'value...' if longer than cols
         type: String,
         computed: 'shortenValue(value)'
         },

--- a/client-js/app/elements/expandable-input.html
+++ b/client-js/app/elements/expandable-input.html
@@ -1,5 +1,6 @@
 <dom-module id="expandable-input">
   <template>
+    <iron-a11y-keys keys="enter" on-keys-pressed="submitForm">
 
      <!--   <input is="iron-input" id="input"
           aria-labelledby$="[[_ariaLabelledBy]]"
@@ -31,12 +32,13 @@
           on-click="testFunc">-->
           
       <paper-textarea id="foo" bind-value="{{value_short}}" label="{{value_short}}" rows="[[focus_rows]]" max-rows="4"></paper-textarea>
-
+    </iron-a11y-keys>
   </template>
   <script>
   Polymer({
     is: "expandable-input",
     properties: {
+      name: {stype: String},
       value: {type: String},
       value_short: {
         type: String,
@@ -51,14 +53,15 @@
     behaviors: [
       Polymer.IronFormElementBehavior,
       Polymer.PaperInputBehavior,
-      Polymer.IronControlState
+      Polymer.IronControlState,
+      Polymer.PaperInputBehaviorImpl
                ],
     ready: function() {
      console.log("ready, focus is:", this.focused);
      this.addEventListener('focused-changed', this.testFocus);
     },
     shortenValue: function(value) {
-      console.log(value.length);
+      //console.log(value.length);
       if (!this.focused){
         var field_len = 7;
         if (value.length > field_len){
@@ -81,6 +84,11 @@
       } else {
         this.focus_rows=1;
       }
+    },
+    submitForm: function(){
+      //console.log('value', this.name);
+      //this.focused = false;
+      this.fire('iron-form-submit', [this.name, this.$.foo.value]);
     }
   });
 

--- a/client-js/app/elements/expandable-input.html
+++ b/client-js/app/elements/expandable-input.html
@@ -1,37 +1,27 @@
-<dom-module id="expandable-input">
-  <template>
-    <iron-a11y-keys keys="enter" on-keys-pressed="submitForm">
+<!-- 
+Expandable input. Takes a registry key value and shortens it to fit on the 
+screen. When clicked on reveals an editable text box which is shifted into 
+focus. Enter fires 'iron-form-submit' which sends the key, value pair as 
+event.detail
+ -->
 
-     <!--   <input is="iron-input" id="input"
-          aria-labelledby$="[[_ariaLabelledBy]]"
-          aria-describedby$="[[_ariaDescribedBy]]"
-          disabled$="[[disabled]]"
-          bind-value="{{value_short}}"
-          invalid="{{invalid}}"
-          prevent-invalid-input="[[preventInvalidInput]]"
-          allowed-pattern="[[allowedPattern]]"
-          validator="[[validator]]"
-          type$="[[type]]"
-          pattern$="[[pattern]]"
-          required$="[[required]]"
-          autocomplete$="[[autocomplete]]"
-          autofocus$="[[autofocus]]"
-          inputmode$="[[inputmode]]"
-          minlength$="[[minlength]]"
-          maxlength$="[[maxlength]]"
-          min$="[[min]]"
-          max$="[[max]]"
-          step$="[[step]]"
-          name$="[[name]]"
-          placeholder$="[[placeholder]]"
-          readonly$="[[readonly]]"
-          list$="[[list]]"
-          size$="[[size]]"
-          autocapitalize$="[[autocapitalize]]"
-          autocorrect$="[[autocorrect]]"
-          on-click="testFunc">-->
-          
-      <paper-textarea id="foo" bind-value="{{value_short}}" label="{{value_short}}" rows="[[focus_rows]]" max-rows="4"></paper-textarea>
+<dom-module id="expandable-input">
+  <style>
+  #long{
+    visibility: hidden;
+    position: absolute;
+    width: 80%;
+  }
+  </style>
+  <template >
+    <iron-a11y-keys keys="enter" on-keys-pressed="submitForm">
+    <!-- TODO remap newline from enter to "ctrl enter" -->
+      <div id="long">
+        <textarea id="input" value="{{value::input}}" rows="[[compRows]]" cols="[[cols]]"></textarea>
+      </div>
+      <div id="short">
+        <paper-item on-click="selectField" id="static" label="{{value_short}}">{{value_short}}</paper-item>
+      </div>
     </iron-a11y-keys>
   </template>
   <script>
@@ -41,13 +31,20 @@
       name: {stype: String},
       value: {type: String},
       value_short: {
+        //holds the shortened value which renders as 'value...' if longer than
+        //cols
         type: String,
-        computed: 'shortenValue(value)',
-        bind: 'focused' 
+        computed: 'shortenValue(value)'
         },
-      focus_rows: {
-        type: Number,
-        default: 1,
+        compRows: {
+          //computed number of rows for input
+          type: Number,
+          value: 1
+        },
+        cols: {
+          //number of characters in text field. Not sized dynamically. For now
+          type: Number,
+          value: 100
         }
     },
     behaviors: [
@@ -57,40 +54,45 @@
       Polymer.PaperInputBehaviorImpl
                ],
     ready: function() {
-     console.log("ready, focus is:", this.focused);
-     this.addEventListener('focused-changed', this.testFocus);
+      //This focus-changed event handles the revealing and hiding of the static field
+     this.addEventListener('focused-changed', this.fieldFocus);
+    },
+    calculateRows: function(value) {
+      //calculates the number of rows in the editable input field
+      console.log(this.cols,value.length,value.length/this.cols);
+      return Math.ceil(value.length/this.cols); //number of rows in dialog rounded up
     },
     shortenValue: function(value) {
-      //console.log(value.length);
-      if (!this.focused){
-        var field_len = 7;
-        if (value.length > field_len){
-          return value.substr(0,field_len)+'...';
-        }
-        else {
-          return value;
-        }
+      //returned shortened string if longer than this.cols
+      if (value.length>this.cols) {
+        return value.substr(0,this.cols)+'...';
       }
       else {
         return value;
       }
-
     },
-    testFocus: function(){
-      console.log(this.value, ' in focus');
+    fieldFocus: function() {
+      /* When input field brought into focus this enlarges the input field.
+      When focus is passed on, this shrinks the field and hides it behind the
+      static label */
       if (this.focused){
-        this.focus_rows=3;
-        console.log(this.$.foo.offsetWidth);
+        this.compRows = this.calculateRows(this.value);
       } else {
-        this.focus_rows=1;
-      }
+        this.compRows = 1;
+        this.$.short.style.visibility = 'visible';
+        this.$.long.style.visibility = 'hidden';
+      } 
     },
-    submitForm: function(){
-      //console.log('value', this.name);
-      //this.focused = false;
-      this.fire('iron-form-submit', [this.name, this.$.foo.value]);
+    submitForm: function() {
+      //fires submit so event is picked up by correct Polymer listener
+      this.fire('iron-form-submit', [this.name, this.$.input.value]);
+    },
+    selectField: function() {
+      //Hides static field to reveal multi-line input which is given focus
+      this.$.short.style.visibility = 'hidden';
+      this.$.long.style.visibility = 'visible';
+      this.$$('textarea').focus();
     }
   });
-
   </script>
 </dom-module>

--- a/client-js/app/elements/expandable-input.html
+++ b/client-js/app/elements/expandable-input.html
@@ -1,0 +1,88 @@
+<dom-module id="expandable-input">
+  <template>
+
+     <!--   <input is="iron-input" id="input"
+          aria-labelledby$="[[_ariaLabelledBy]]"
+          aria-describedby$="[[_ariaDescribedBy]]"
+          disabled$="[[disabled]]"
+          bind-value="{{value_short}}"
+          invalid="{{invalid}}"
+          prevent-invalid-input="[[preventInvalidInput]]"
+          allowed-pattern="[[allowedPattern]]"
+          validator="[[validator]]"
+          type$="[[type]]"
+          pattern$="[[pattern]]"
+          required$="[[required]]"
+          autocomplete$="[[autocomplete]]"
+          autofocus$="[[autofocus]]"
+          inputmode$="[[inputmode]]"
+          minlength$="[[minlength]]"
+          maxlength$="[[maxlength]]"
+          min$="[[min]]"
+          max$="[[max]]"
+          step$="[[step]]"
+          name$="[[name]]"
+          placeholder$="[[placeholder]]"
+          readonly$="[[readonly]]"
+          list$="[[list]]"
+          size$="[[size]]"
+          autocapitalize$="[[autocapitalize]]"
+          autocorrect$="[[autocorrect]]"
+          on-click="testFunc">-->
+          
+      <paper-textarea id="foo" bind-value="{{value_short}}" label="{{value_short}}" rows="[[focus_rows]]" max-rows="4"></paper-textarea>
+
+  </template>
+  <script>
+  Polymer({
+    is: "expandable-input",
+    properties: {
+      value: {type: String},
+      value_short: {
+        type: String,
+        computed: 'shortenValue(value)',
+        bind: 'focused' 
+        },
+      focus_rows: {
+        type: Number,
+        default: 1,
+        }
+    },
+    behaviors: [
+      Polymer.IronFormElementBehavior,
+      Polymer.PaperInputBehavior,
+      Polymer.IronControlState
+               ],
+    ready: function() {
+     console.log("ready, focus is:", this.focused);
+     this.addEventListener('focused-changed', this.testFocus);
+    },
+    shortenValue: function(value) {
+      console.log(value.length);
+      if (!this.focused){
+        var field_len = 7;
+        if (value.length > field_len){
+          return value.substr(0,field_len)+'...';
+        }
+        else {
+          return value;
+        }
+      }
+      else {
+        return value;
+      }
+
+    },
+    testFocus: function(){
+      console.log(this.value, ' in focus');
+      if (this.focused){
+        this.focus_rows=3;
+        console.log(this.$.foo.offsetWidth);
+      } else {
+        this.focus_rows=1;
+      }
+    }
+  });
+
+  </script>
+</dom-module>

--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -110,9 +110,11 @@
               <td class="label-wide">
                 <form is="iron-form" id="{{item.name}}">
                   <iron-a11y-keys keys="tab" on-keys-pressed="incrementSelector">
-                    <paper-input-container>
+                    <!-- <paper-input-container>
                       <input is="iron-input" name="{{item.name}}" value="{{item.value}}">
-                    </paper-input-container>
+                    </paper-input-container> -->
+
+                      <expandable-input name="{{item.name}}" value="{{item.value}}"></expandable-input>
                   </iron-a11y-keys>
                 </form>
               </td>
@@ -121,7 +123,6 @@
         </tbody>
       </div>
     </table>
-
     <!-- These are the dialogs -->
     <paper-dialog id="doRename">
       <p>Rename "<span>{{selItem}}</span>" to something else</p>

--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -110,9 +110,10 @@
               <td class="label-wide">
                 <form is="iron-form" id="{{item.name}}">
                   <iron-a11y-keys keys="tab" on-keys-pressed="incrementSelector">
-                    <!-- <paper-input-container>
+
+                    <!-- <paper-input-container> 
                       <input is="iron-input" name="{{item.name}}" value="{{item.value}}">
-                    </paper-input-container> -->
+                     </paper-input-container>  -->
 
                       <expandable-input name="{{item.name}}" value="{{item.value}}"></expandable-input>
                   </iron-a11y-keys>

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -182,8 +182,8 @@ export class LabradRegistry extends polymer.Base {
   updateKey(event) {
     console.log('iron-form-submit', event);
     var self = this;
-    var selKey = Object.keys(event.detail)[0];
-    var newVal = event.detail[selKey];
+    var selKey = event.detail[0];
+    var newVal = event.detail[1];
     this.socket.set({path: this.path, key: selKey, value: newVal}).then(
       (resp) => {
         self.repopulateList(resp);


### PR DESCRIPTION
**_Have to update Polymer to 1.1.2**_ `$ bower update` should do the trick

This fixes https://github.com/labrad/scalabrad-web/issues/32 
Adds a new component which displays shortened value for really long values. When clicked on this reveals a mutli-line input dialog which is in focus. Submits with 'enter' key. 

It's a simple enough component that I left the logic as inline javascript, could convert to ts if need be. 

There are a few lame behaviours that need to be ironed out: enter, still briefly adds a newline which is ignored; formatting is different than other "Material design" stuff. But popular opinion is that we should move away from this, so I'm leaving it for now.
