### PR TITLE
Create Expandable dialog

### DIFF
--- a/client-js/app/elements/elements.html
+++ b/client-js/app/elements/elements.html
@@ -1,11 +1,13 @@
 <!-- Paper, Iron and Platinum elements -->
 <link rel="import" href="../bower_components/iron-a11y-keys/iron-a11y-keys.html">
 <link rel="import" href="../bower_components/iron-flex-layout/classes/iron-flex-layout.html">
+<link rel="import" href="../bower_components/iron-collapse/iron-collapse.html">
 <link rel="import" href="../bower_components/iron-form/iron-form.html">
 <link rel="import" href="../bower_components/iron-icons/editor-icons.html">
 <link rel="import" href="../bower_components/iron-icons/hardware-icons.html">
 <link rel="import" href="../bower_components/iron-icons/communication-icons.html">
 <link rel="import" href="../bower_components/iron-icons/iron-icons.html">
+<link rel="import" href="../bower_components/iron-input/iron-input.html">
 <link rel="import" href="../bower_components/iron-pages/iron-pages.html">
 <link rel="import" href="../bower_components/iron-selector/iron-selector.html">
 <link rel="import" href="../bower_components/paper-button/paper-button.html">
@@ -16,6 +18,7 @@
 <link rel="import" href="../bower_components/paper-icon-button/paper-icon-button.html">
 <link rel="import" href="../bower_components/paper-input/paper-input.html">
 <link rel="import" href="../bower_components/paper-input/paper-input-container.html">
+<link rel="import" href="../bower_components/paper-input/paper-textarea.html">
 <link rel="import" href="../bower_components/paper-item/paper-item.html">
 <link rel="import" href="../bower_components/paper-item/paper-icon-item.html">
 <link rel="import" href="../bower_components/paper-material/paper-material.html">
@@ -40,3 +43,4 @@
 <link rel="import" href="labrad-server.html">
 <link rel="import" href="menu-button.html">
 <link rel="import" href="selectable-table.html">
+<link rel="import" href="expandable-input.html">

--- a/client-js/app/elements/expandable-input.html
+++ b/client-js/app/elements/expandable-input.html
@@ -1,0 +1,83 @@
+<!-- 
+Expandable input. Takes a registry key value and shortens it to fit on the 
+screen. When clicked on reveals an editable text box which is shifted into 
+focus. Enter fires 'iron-form-submit' which sends the key, value pair as 
+event.detail
+ -->
+
+<dom-module id="expandable-input">
+  <style>
+  #long {
+    width: 80%;
+  }
+  </style>
+  <template >
+    <iron-a11y-keys keys="enter" on-keys-pressed="submitForm">
+    <!-- TODO remap newline from enter to "ctrl enter" -->
+      <paper-textarea id="long" value="{{value::input}}" cols="[[cols]]" no-label-float hidden></paper-textarea>
+      <paper-item id="short" on-click="selectField" label="{{valueShort}}">{{valueShort}}</paper-item>
+    </iron-a11y-keys>
+  </template>
+  <script>
+  Polymer({
+    is: 'expandable-input',
+    properties: {
+      name: {stype: String},
+      value: {type: String},
+      valueShort: {
+      //holds the shortened value which renders as 'value...' if longer than cols
+        type: String,
+        computed: 'shortenValue(value)'
+        },
+        cols: {
+          //number of characters in text field. Not sized dynamically. For now
+          type: Number,
+          value: 60
+        }
+    },
+    behaviors: [
+      Polymer.IronFormElementBehavior,
+      Polymer.PaperInputBehavior,
+      Polymer.IronControlState,
+      Polymer.PaperInputBehaviorImpl
+               ],
+    ready: function() {
+      //This focus-changed event handles the revealing and hiding of the static field
+      this.addEventListener('focused-changed', this.fieldFocus);
+    },
+    calculateRows: function(value) {
+      //calculates the number of rows in the editable input field
+      console.log(this.cols,value.length,value.length/this.cols);
+      return Math.ceil(value.length/this.cols); //number of rows in dialog rounded up
+    },
+    shortenValue: function(value) {
+      //returned shortened string if longer than this.cols
+      if (value.length>this.cols) {
+        return value.substr(0,this.cols)+'...';
+      }
+      else {
+        return value;
+      }
+    },
+    fieldFocus: function() {
+      /* When input field brought into focus this enlarges the input field.
+      When focus is passed on, this shrinks the field and hides it behind the
+      static label */
+      if (!this.focused) {
+        this.$.short.hidden = false;
+        this.$.long.hidden = true;
+      }
+    },
+    submitForm: function() {
+      //fires submit so event is picked up by correct Polymer listener
+      this.fire('iron-form-submit', [this.name, this.$.long.$.input.$.textarea.value]);
+    },
+    selectField: function() {
+      //Hides static field to reveal multi-line input which is given focus
+      this.$.short.hidden = true;
+      this.$.long.hidden = false;
+      this.$.long.$.input.$.textarea.focus();
+    }
+  });
+  </script>
+</dom-module>

--- a/client-js/app/elements/expandable-input.html
+++ b/client-js/app/elements/expandable-input.html
@@ -1,3 +1,6 @@
+<link rel="import" href="../bower_components/paper-input/paper-textarea.html">
+<link rel="import" href="../bower_components/paper-item/paper-item.html">
+<link rel="import" href="../bower_components/paper-tooltip/paper-tooltip.html">
 <!-- 
 Expandable input. Takes a registry key value and shortens it to fit on the 
 screen. When clicked on reveals an editable text box which is shifted into 
@@ -12,48 +15,43 @@ event.detail
   }
   </style>
   <template >
-    <iron-a11y-keys keys="enter" on-keys-pressed="submitForm">
-    <!-- TODO remap newline from enter to "ctrl enter" -->
-      <paper-textarea id="long" value="{{value::input}}" cols="[[cols]]" no-label-float hidden></paper-textarea>
-      <paper-item id="short" on-click="selectField" label="{{valueShort}}">{{valueShort}}</paper-item>
-    </iron-a11y-keys>
+    <div>
+      <iron-a11y-keys keys="shift+enter" on-keys-pressed="submitForm">
+      <!-- TODO remap newline from enter to "ctrl enter" -->
+        <paper-textarea id="long" value="{{value::input}}" no-label-float hidden></paper-textarea>
+        <paper-item id="short" on-click="selectField" label="{{valueShort}}">{{valueShort}}</paper-item>
+        <paper-tooltip for="long">shift+enter to submit</paper-tooltip>
+      </iron-a11y-keys>
+    </div>
   </template>
   <script>
   Polymer({
     is: 'expandable-input',
     properties: {
-      name: {stype: String},
+      name: {type: String},
       value: {type: String},
+      cols: {
+        type: Number,
+        value: 80
+      },
       valueShort: {
-      //holds the shortened value which renders as 'value...' if longer than cols
+        //holds the shortened value which renders as 'value...' if longer than cols
         type: String,
         computed: 'shortenValue(value)'
-        },
-        cols: {
-          //number of characters in text field. Not sized dynamically. For now
-          type: Number,
-          value: 60
-        }
+      }
     },
     behaviors: [
-      Polymer.IronFormElementBehavior,
-      Polymer.PaperInputBehavior,
-      Polymer.IronControlState,
-      Polymer.PaperInputBehaviorImpl
-               ],
+      Polymer.IronControlState
+    ],
     ready: function() {
       //This focus-changed event handles the revealing and hiding of the static field
       this.addEventListener('focused-changed', this.fieldFocus);
-    },
-    calculateRows: function(value) {
-      //calculates the number of rows in the editable input field
-      console.log(this.cols,value.length,value.length/this.cols);
-      return Math.ceil(value.length/this.cols); //number of rows in dialog rounded up
+      this.$.long.$.input.$.textarea.addEventListener('keypress', this.keyPressed);
     },
     shortenValue: function(value) {
       //returned shortened string if longer than this.cols
-      if (value.length>this.cols) {
-        return value.substr(0,this.cols)+'...';
+      if (value.length > this.cols) {
+        return value.substr(0, this.cols) + '...';
       }
       else {
         return value;
@@ -68,9 +66,15 @@ event.detail
         this.$.long.hidden = true;
       }
     },
+    keyPressed: function(event) {
+      // swallow shift-enter, which is used for submitting a value
+      if (event.shiftKey && event.keyCode == 13) {
+        event.preventDefault();
+      }
+    },
     submitForm: function() {
       //fires submit so event is picked up by correct Polymer listener
-      this.fire('iron-form-submit', [this.name, this.$.long.$.input.$.textarea.value]);
+      this.fire('iron-form-submit', { key: this.name, value: this.$.long.$.input.$.textarea.value });
     },
     selectField: function() {
       //Hides static field to reveal multi-line input which is given focus

--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -106,9 +106,14 @@
               </td>
               <td class="label-wide">
                 <form is="iron-form" id="{{item.name}}">
-                  <paper-input-container no-label-float>
-                    <input is="iron-input" name="{{item.name}}" value="{{item.value}}">
-                  </paper-input-container>
+                  <iron-a11y-keys keys="tab" on-keys-pressed="incrementSelector">
+
+                    <!-- <paper-input-container> 
+                      <input is="iron-input" name="{{item.name}}" value="{{item.value}}">
+                     </paper-input-container>  -->
+
+                      <expandable-input name="{{item.name}}" value="{{item.value}}"></expandable-input>
+                  </iron-a11y-keys>
                 </form>
               </td>
             </tr>
@@ -121,6 +126,7 @@
 
     <paper-dialog id="newKeyDialog" modal>
       <h1>Create new key</h1>
+
       <form>
         <paper-input id="newKeyInput" label="Key"></paper-input>
         <paper-textarea id="newValueInput" label="Value"></paper-textarea>

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -293,10 +293,9 @@ export class LabradRegistry extends polymer.Base {
 
   @listen('iron-form-submit')
   updateKey(event) {
-    console.log('iron-form-submit', event);
     var self = this;
-    var selKey = event.detail[0];
-    var newVal = event.detail[1];
+    var selKey = event.detail.key;
+    var newVal = event.detail.value;
     this.socket.set({path: this.path, key: selKey, value: newVal}).then(
       (resp) => {
         self.repopulateList(resp);

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -290,4 +290,20 @@ export class LabradRegistry extends polymer.Base {
       );
     }
   }
+
+  @listen('iron-form-submit')
+  updateKey(event) {
+    console.log('iron-form-submit', event);
+    var self = this;
+    var selKey = event.detail[0];
+    var newVal = event.detail[1];
+    this.socket.set({path: this.path, key: selKey, value: newVal}).then(
+      (resp) => {
+        self.repopulateList(resp);
+        self.selKey = null;
+      },
+      (reason) => self.handleError(reason)
+    );
+  }
+
 }

--- a/client-js/bower.json
+++ b/client-js/bower.json
@@ -7,7 +7,8 @@
     "paper-elements": "PolymerElements/paper-elements#1.0.1",
     "platinum-elements": "PolymerElements/platinum-elements#1.0.0",
     "neon-elements": "PolymerElements/neon-elements#1.0.0",
-    "polymer-ts": "nippur72/PolymerTS#~0.1.13"
+    "polymer-ts": "nippur72/PolymerTS#~0.1.13",
+    "paper-tooltip": "PolymerElements/paper-tooltip#~1.1.0"
   },
   "devDependencies": {
     "web-component-tester": "*",


### PR DESCRIPTION
This is a branch off a previous commit to finish up the expandable dialog using javascript instead of TypeScript. I couldn't figure out how to resolve the detached head, so I created a new branch :/ 

Added a Polymer Tooltip component to hint at keyboard shortcuts, for this to work correctly you have to install by running
`$ bower install --save PolymerElements/paper-tooltip`
from /client-js
