### PR TITLE
fix menu-bar rendering issue

### DIFF
--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -8,14 +8,17 @@
     :host {
       display: block;
     }
+
     #reg-menu {
       position: fixed;
-       @apply(--shadow-elevation-3dp);
-       padding-top: 5px;
-       padding-bottom: 5px;
-       background-color: white;
-       z-index: +1;
+      top: 140px;
+      left: 33px;
+      @apply(--shadow-elevation-2dp);
+      padding-top: 5px;
+      padding-bottom: 5px;
+      background-color: white;
     }
+
     #reg-area {
       margin-top: 85px;
       padding-top: 12px;
@@ -24,6 +27,7 @@
       @apply(--shadow-elevation-2dp);
       height: 100%;
     }
+
     .iron-selected {
       background-color: #ddd;
     }
@@ -33,11 +37,7 @@
       border: 1px solid #ccc;
       border-top: none;
     }
-    .reg-list { 
-      padding-top: 12px;
-      display: table; 
-      border: 1px solid;
-    }
+    
     table {
       width: 100%;
     }
@@ -87,20 +87,11 @@
     }
   </style>
   <template>
-    <div id="reg-menu">
-      <section>
-        <menu-button on-click="newKeyClicked" name="new key" icon-name="create"></menu-button>
-        <menu-button on-click="newFolderClicked" name="new folder" icon-name="folder-open"></menu-button>
-        <menu-button on-click="copyClicked" name="copy" icon-name="content-copy" disabled={{!selected}}></menu-button>
-        <menu-button on-click="renameClicked" name="rename" icon-name="code" disabled={{!selected}}></menu-button>
-        <menu-button on-click="deleteClicked" name="delete" icon-name="delete" disabled={{!selected}}></menu-button>
-      </section>
-    </div>
     <div id="reg-area">
       <div id="search-bar">
         <iron-icon icon="search"></iron-icon>
         <input type="search" id="search" value="{{filterText::input}}" placeholder="search registry">
-      </div>
+      </div> 
       <table>
         <tbody is="selectable-table" attr-for-selected="name" selected="{{selDir}}" on-tap="selectDir">
           <template id="dirList" is="dom-repeat" items="{{dirs}}" filter="filterFunc">
@@ -123,11 +114,6 @@
               <td class="label-wide">
                 <form is="iron-form" id="{{item.name}}">
                   <iron-a11y-keys keys="tab" on-keys-pressed="incrementSelector">
-
-                    <!-- <paper-input-container> 
-                      <input is="iron-input" name="{{item.name}}" value="{{item.value}}">
-                     </paper-input-container>  -->
-
                       <expandable-input name="{{item.name}}" value="{{item.value}}"></expandable-input>
                   </iron-a11y-keys>
                 </form>
@@ -137,7 +123,15 @@
         </tbody>
       </table>
     </div>
-
+    <div id="reg-menu">
+      <section>
+        <menu-button on-click="newKeyClicked" name="new key" icon-name="create"></menu-button>
+        <menu-button on-click="newFolderClicked" name="new folder" icon-name="folder-open"></menu-button>
+        <menu-button on-click="copyClicked" name="copy" icon-name="content-copy" disabled={{!selected}}></menu-button>
+        <menu-button on-click="renameClicked" name="rename" icon-name="code" disabled={{!selected}}></menu-button>
+        <menu-button on-click="deleteClicked" name="delete" icon-name="delete" disabled={{!selected}}></menu-button>
+      </section>
+    </div>
     <!-- Dialogs for various registry operations -->
 
     <paper-dialog id="newKeyDialog" modal>


### PR DESCRIPTION
Fixes #34 

Basically re-ordering the divs removes the need to use z-index. avoiding z-index plays nice.
The div that is placed last, shows up on top of the pile rendering wise.

The lesson apparently: never use z-index.
