### PR TITLE
remove magic numbers from menu alignment

### DIFF
--- a/client-js/app/elements/app-theme.html
+++ b/client-js/app/elements/app-theme.html
@@ -22,6 +22,7 @@
   --secondary-text-color: #727272;
   --disabled-text-color: #bdbdbd;
   --divider-color: #B6B6B6;
+  --maintoolbar-height: 64px;
 
   /* Components */
 
@@ -50,6 +51,7 @@ paper-material {
   box-shadow: 0 4px 5px 0 rgba(0,0,0,.14),
   0 2px 9px 1px rgba(0,0,0,.12),
   0 4px 2px -2px rgba(0,0,0,.2);
+  height: var(--maintoolbar-height);
 }
 
 paper-menu iron-icon {
@@ -62,8 +64,8 @@ paper-menu iron-icon {
 }
 
 #mainToolbar .bottom {
-  padding-bottom: 120px;
-  margin-left: 30px;
+  padding-bottom: 0px;
+  margin-left: 50px;
 }
 
 paper-menu a {
@@ -150,7 +152,7 @@ paper-menu a {
   }
 
   .appname {
-    font-size: 24px;
+    font-size: 18px;
     padding-bottom: 0px;
   }
 }

--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -11,8 +11,8 @@
 
     #reg-menu {
       position: fixed;
-      top: 140px;
-      left: 33px;
+      top: var(--maintoolbar-height);
+      transform: translateY(50%);
       @apply(--shadow-elevation-2dp);
       padding-top: 5px;
       padding-bottom: 5px;
@@ -20,8 +20,7 @@
     }
 
     #reg-area {
-      margin-top: 85px;
-      padding-top: 12px;
+      margin-top: 5em;
       background-color: white;
       display: inline-block;
       @apply(--shadow-elevation-2dp);
@@ -31,16 +30,18 @@
     .iron-selected {
       background-color: #ddd;
     }
+
     .iron-selector {
       width: 100%;
       display: block;
       border: 1px solid #ccc;
       border-top: none;
     }
-    
+
     table {
       width: 100%;
     }
+
     tbody {
       display:table-header-group;
     }


### PR DESCRIPTION
Edited css:

added a css variable to define the height of the menu in the maintoolbar. Locating registry editor menu based on that. 
Also, fixed text in maintoolbar so it appears.
