### PR TITLE
Edit registry values in dialog box instead of inline.

### DIFF
--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -113,11 +113,7 @@
                 <dir-item kind="key">{{item.name}}</dir-item>
               </td>
               <td class="label-wide">
-                <form is="iron-form" id="{{item.name}}">
-                  <iron-a11y-keys keys="tab" on-keys-pressed="incrementSelector">
-                      <expandable-input name="{{item.name}}" value="{{item.value}}"></expandable-input>
-                  </iron-a11y-keys>
-                </form>
+                <paper-item key-name="{{item.name}}" on-dblclick="editValueClicked">{{item.value}}</paper-item>
               </td>
             </tr>
           </template>
@@ -144,6 +140,17 @@
       </form>
       <div class="buttons"> 
         <paper-button on-click="doNewKey" dialog-confirm>OK</paper-button>
+        <paper-button dialog-dismiss>CANCEL</paper-button>
+      </div>
+    </paper-dialog>
+
+    <paper-dialog id="editValueDialog" modal>
+      <h1>Edit <span>{{selKey}}</span></h1>
+      <form>
+        <paper-textarea id="editValueInput" label="Value"></paper-textarea>
+      </form>
+      <div class="buttons">
+        <paper-button on-click="doEditValue" dialog-confirm autofocus>OK</paper-button>
         <paper-button dialog-dismiss>CANCEL</paper-button>
       </div>
     </paper-dialog>

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -26,10 +26,10 @@ export class LabradRegistry extends polymer.Base {
 
   @property({type: String, notify: true, value: null})
   selectType: string;
-    
+
   @property({type: String, notify: true, value: ''})
   filterText: string;
-  
+
   regex: RegExp; //regular expression for string comparison
 
   //Helper Functions
@@ -48,8 +48,6 @@ export class LabradRegistry extends polymer.Base {
     this.regex = new RegExp(this.filterText, 'i');
     this.$.dirList.render();
     this.$.keyList.render();
-
-
   }
 
   filterFunc(item) {
@@ -164,6 +162,46 @@ export class LabradRegistry extends polymer.Base {
     }
   }
 
+  /**
+   * Launch the value edit dialog.
+   */
+  editValueClicked(event) {
+    var dialog = this.$.editValueDialog,
+        editValueElem = this.$.editValueInput,
+        name = event.target.keyName,
+        value: string = null,
+        found = false;
+    for (let item of this.keys) {
+      if (item.name == name) {
+        value = item.value;
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      return;
+    }
+    editValueElem.value = value;
+    dialog.keyName = name;
+    dialog.open();
+    window.setTimeout(() => editValueElem.$.input.$.textarea.focus(), 0);
+  }
+
+  /**
+   * Submit the edited value to the server.
+   */
+  doEditValue() {
+    var self = this,
+        key = this.$.editValueDialog.keyName,
+        newVal = this.$.editValueInput.value;
+    this.socket.set({path: this.path, key: key, value: newVal}).then(
+      (resp) => {
+        self.repopulateList(resp);
+        self.selKey = null;
+      },
+      (reason) => self.handleError(reason)
+    );
+  }
 
   /**
    * Launch new folder dialog.


### PR DESCRIPTION
This is much simpler than the inline editing due to the modal interface and generally it just works (does not rely on so many quirks of polymer element behavior). If we have time in the future to tweak and test, we can revisit the inline editing.

Fixes #60 and #61.
