### PR TITLE
Only trigger app-link event if left button is pressed.

### DIFF
--- a/client-js/app/elements/app-link.html
+++ b/client-js/app/elements/app-link.html
@@ -10,7 +10,7 @@
     },
 
     onClick: function(e) {
-      if (e.ctrlKey || e.metaKey) {
+      if (e.ctrlKey || e.metaKey || e.button !== 0) {
         return true;
       }
       this.fire('app-link-click', {path: this.path});


### PR DESCRIPTION
If using the middle button, the default link behavior will occur, which typically opens a link in a new tab.

@ejeffrey, I don't have a mouse with a middle button. Feel free to test this is you like, or else I'll be able to get to this on monday.

Fixes #67
