### PR TITLE
Use arrow functions with lexical this instead of self and bind.

### DIFF
--- a/client-js/app/elements/labrad-nodes.ts
+++ b/client-js/app/elements/labrad-nodes.ts
@@ -81,8 +81,7 @@ export class LabradInstanceController extends polymer.Base {
    * state of this particular server instance.
    */
   updateButtonState(status: string) {
-    var self = this,
-        options = {info: false, start: false, stop: false, restart: false};
+    var options = {info: false, start: false, stop: false, restart: false};
     switch (status) {
       case 'STOPPED': this.active = false; options.start = true; break;
       case 'STARTING': this.active = true; break;
@@ -90,8 +89,8 @@ export class LabradInstanceController extends polymer.Base {
       case 'STOPPING': this.active = true; break;
       default: break;
     }
-    function updateButton(name: string) {
-      var button = self.$[name];
+    var updateButton = (name: string): void => {
+      var button = this.$[name];
       if (options[name]) {
         button.removeAttribute('disabled');
       } else {
@@ -118,11 +117,10 @@ export class LabradNodeController extends polymer.Base {
 
   @listen('refresh.click')
   onRefresh() {
-    var self = this;
     this.active = true;
     this.api.refreshNode(this.name).then(
-      (result) => { self.active = false; },
-      (error) => { self.active = false; }
+      (result) => { this.active = false; },
+      (error) => { this.active = false; }
     );
   }
 }
@@ -168,8 +166,8 @@ export class LabradNodes extends polymer.Base {
   apiChanged(newApi: NodeApi, oldApi: NodeApi) {
     console.log('apiChanged', newApi, oldApi);
     if (this.defined(newApi)) {
-      newApi.nodeStatus.add(this.onNodeStatus.bind(this), this.lifetime);
-      newApi.serverStatus.add(this.onServerStatus.bind(this), this.lifetime);
+      newApi.nodeStatus.add((msg) => this.onNodeStatus(msg), this.lifetime);
+      newApi.serverStatus.add((msg) => this.onServerStatus(msg), this.lifetime);
     }
   }
 
@@ -177,7 +175,7 @@ export class LabradNodes extends polymer.Base {
   managerChanged(newManager: ManagerApi, oldManager: ManagerApi) {
     console.log('managerChanged', newManager, oldManager);
     if (this.defined(newManager)) {
-      newManager.serverDisconnected.add(this.onServerDisconnected.bind(this), this.lifetime);
+      newManager.serverDisconnected.add((msg) => this.onServerDisconnected(msg), this.lifetime);
     }
   }
 

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -117,15 +117,14 @@ export class LabradRegistry extends polymer.Base {
    */
   @listen('iron-form-submit')
   updateKey(event) {
-    var self = this;
     var selKey = event.detail.key;
     var newVal = event.detail.value;
     this.socket.set({path: this.path, key: selKey, value: newVal}).then(
       (resp) => {
-        self.repopulateList(resp);
-        self.selKey = null;
+        this.repopulateList(resp);
+        this.selKey = null;
       },
-      (reason) => self.handleError(reason)
+      (reason) => this.handleError(reason)
     );
   }
 
@@ -147,14 +146,13 @@ export class LabradRegistry extends polymer.Base {
    * Create new key.
    */
   doNewKey() {
-    var self = this;
     var newKey = this.$.newKeyInput.value;
     var newVal = this.$.newValueInput.value;
 
     if (newKey) {
       this.socket.set({path: this.path, key: newKey, value: newVal}).then(
-        (resp) => self.repopulateList(resp),
-        (reason) => self.handleError(reason)
+        (resp) => this.repopulateList(resp),
+        (reason) => this.handleError(reason)
       );
     }
     else {
@@ -191,15 +189,14 @@ export class LabradRegistry extends polymer.Base {
    * Submit the edited value to the server.
    */
   doEditValue() {
-    var self = this,
-        key = this.$.editValueDialog.keyName,
+    var key = this.$.editValueDialog.keyName,
         newVal = this.$.editValueInput.value;
     this.socket.set({path: this.path, key: key, value: newVal}).then(
       (resp) => {
-        self.repopulateList(resp);
-        self.selKey = null;
+        this.repopulateList(resp);
+        this.selKey = null;
       },
-      (reason) => self.handleError(reason)
+      (reason) => this.handleError(reason)
     );
   }
 
@@ -218,13 +215,12 @@ export class LabradRegistry extends polymer.Base {
    * Create new folder.
    */
   doNewFolder() {
-    var self = this,
-        newFolder = this.$.newFolderInput.value;
+    var newFolder = this.$.newFolderInput.value;
 
     if (newFolder) {
       this.socket.mkDir({path: this.path, dir: newFolder}).then(
-        (resp) => self.repopulateList(resp),
-        (reason) => self.handleError(reason)
+        (resp) => this.repopulateList(resp),
+        (reason) => this.handleError(reason)
       );
     }
     else {
@@ -250,20 +246,19 @@ export class LabradRegistry extends polymer.Base {
    * Copy the selected key or folder.
    */
   doCopy() {
-    var self = this;
     var newName =  this.$.copyNameInput.value;
     var newPath = JSON.parse(this.$.copyPathInput.value);
 
     if (this.selectType === 'dir') {
       this.socket.copyDir({path: this.path, dir: this.selDir, newPath: newPath, newDir: newName}).then(
-        (resp) => self.repopulateList(resp),
-        (reason) => self.handleError(reason)
+        (resp) => this.repopulateList(resp),
+        (reason) => this.handleError(reason)
       );
     }
     else if (this.selectType === 'key') {
       this.socket.copy({path: this.path, key: this.selKey, newPath: newPath, newKey: newName}).then(
-        (resp) => self.repopulateList(resp),
-        (reason) => self.handleError(reason)
+        (resp) => this.repopulateList(resp),
+        (reason) => this.handleError(reason)
       );
     }
   }
@@ -292,8 +287,7 @@ export class LabradRegistry extends polymer.Base {
    * Rename the selected key or folder.
    */
   doRename() {
-    var self = this,
-        newName = this.$.renameInput.value;
+    var newName = this.$.renameInput.value;
 
     var name: string;
     switch (this.selectType) {
@@ -306,14 +300,14 @@ export class LabradRegistry extends polymer.Base {
     if (newName) {
       if (this.selectType === 'dir') {
         this.socket.renameDir({path: this.path, dir: name, newDir: newName}).then(
-          (resp) => self.repopulateList(resp),
-          (reason) => self.handleError(reason)
+          (resp) => this.repopulateList(resp),
+          (reason) => this.handleError(reason)
         );
       }
       else if (this.selectType === 'key') {
         this.socket.rename({path: this.path, key: name, newKey: newName}).then(
-          (resp) => self.repopulateList(resp),
-          (reason) => self.handleError(reason)
+          (resp) => this.repopulateList(resp),
+          (reason) => this.handleError(reason)
         );
       }
     }
@@ -334,18 +328,16 @@ export class LabradRegistry extends polymer.Base {
    * Delete the selected key or folder.
    */
   doDelete() {
-    var self = this;
-
     if (this.selectType === 'dir') {
       this.socket.rmDir({path: this.path, dir: this.selDir}).then(
-        (resp) => self.repopulateList(resp),
-        (reason) => self.handleError(reason)
+        (resp) => this.repopulateList(resp),
+        (reason) => this.handleError(reason)
       );
     }
     else if (this.selectType === 'key') {
       this.socket.del({path: this.path, key: this.selKey}).then(
-        (resp) => self.repopulateList(resp),
-        (reason) => self.handleError(reason)
+        (resp) => this.repopulateList(resp),
+        (reason) => this.handleError(reason)
       );
     }
   }

--- a/client-js/app/scripts/observable.ts
+++ b/client-js/app/scripts/observable.ts
@@ -23,7 +23,7 @@ export class Observable<A> {
   add(callback: (A) => void, lifetime?: Lifetime): (A) => void {
     this.callbacks.add(callback);
     if (lifetime) {
-      lifetime.defer((() => this.remove(callback)).bind(this));
+      lifetime.defer(() => this.remove(callback));
     }
     return callback;
   }


### PR DESCRIPTION
I just learned (and verified with manual tests) that arrow functions in typescript (and es6) capture `this` from the surrounding lexical scope, so there's no need for the `var self = this` hackery when using arrow functions. Changed a number of places in labrad-registry to reflect this, and also used arrow functions in place of `bind` in a few spots where methods are being invoked as callbacks. I'm really glad to have found this out, as it fixes one of the big annoyances with javascript callbacks.
