### PR TITLE
Fix hashbang config on login.

### DIFF
--- a/client-js/app/scripts/app.ts
+++ b/client-js/app/scripts/app.ts
@@ -347,7 +347,7 @@ window.addEventListener('WebComponentsReady', () => {
       error => attemptLogin(window.localStorage)
     )
     .then(
-      success => page({hashbang: true}),
+      success => page({hashbang: false}),
       error => loginWithDialog()
     );
 });


### PR DESCRIPTION
Had the wrong hashbang config for `page` when logging in with saved credentials. This causes the app to use old-school hashbang urls like `http://localhost/#!/nodes/` instead of nice clean urls like `http://localhost/nodes/`.
