### PR TITLE
Upgrade Typescript and PolymerTS

### DIFF
--- a/client-js/app/elements/labrad-grapher-dataset.html
+++ b/client-js/app/elements/labrad-grapher-dataset.html
@@ -37,7 +37,7 @@
         type: String,
         notify: true,
       },
-      dataset: {
+      datasetName: {
         type: String,
         notify: true
       },

--- a/client-js/app/elements/labrad-pages.html
+++ b/client-js/app/elements/labrad-pages.html
@@ -58,7 +58,7 @@
     <paper-material elevation="0">
       <labrad-grapher-dataset
           path={{path}}
-          dataset={{dataset}}
+          dataset-name={{datasetName}}
           parent-url={{parentUrl}}>
       </labrad-grapher-dataset>
     </paper-material>

--- a/client-js/app/elements/labrad-pages.ts
+++ b/client-js/app/elements/labrad-pages.ts
@@ -116,11 +116,12 @@ export class GrapherPage extends polymer.Base {
 
 @component("labrad-page-dataset")
 export class DatasetPage extends polymer.Base {
+
   @property({type: Array})
   path: Array<string>;
 
   @property({type: String})
-  dataset: string;
+  datasetName: string;
 
   @property({type: String})
   parentUrl: string;
@@ -132,7 +133,7 @@ export class DatasetPage extends polymer.Base {
   ): DatasetPage {
     var inst = <DatasetPage> DatasetPage.create();
     inst.path = path;
-    inst.dataset = dataset;
+    inst.datasetName = dataset;
     inst.parentUrl = parentUrl;
     return inst;
   }

--- a/client-js/app/scripts/app.ts
+++ b/client-js/app/scripts/app.ts
@@ -68,7 +68,7 @@ window.addEventListener('WebComponentsReady', () => {
   var dv = new datavault.DataVaultService(socket);
   var node = new nodeApi.NodeService(socket);
 
-  function setContent(elem, route: string, breadcrumbs?: Array<{name: string; isLink: boolean; url?: string}>): void {
+  function setContent(elem: HTMLElement, route: string, breadcrumbs?: Array<{name: string; isLink: boolean; url?: string}>): void {
     app.route = route;
     if (breadcrumbs) {
       app.hasBreadcrumbs = true;

--- a/client-js/bower.json
+++ b/client-js/bower.json
@@ -7,7 +7,7 @@
     "paper-elements": "PolymerElements/paper-elements#1.0.1",
     "platinum-elements": "PolymerElements/platinum-elements#1.0.0",
     "neon-elements": "PolymerElements/neon-elements#1.0.0",
-    "polymer-ts": "nippur72/PolymerTS#~0.1.13",
+    "polymer-ts": "nippur72/PolymerTS#~0.1.19",
     "paper-tooltip": "PolymerElements/paper-tooltip#~1.1.0"
   },
   "devDependencies": {

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -22,7 +22,7 @@
     "gulp-size": "^1.0.0",
     "gulp-sourcemaps": "^1.5.2",
     "gulp-tslint": "^3.0.1-beta",
-    "gulp-typescript": "^2.7.6",
+    "gulp-typescript": "^2.8.1",
     "gulp-uglify": "^1.2.0",
     "gulp-uncss": "^1.0.1",
     "gulp-useref": "^1.1.2",
@@ -35,7 +35,7 @@
     "opn": "^1.0.0",
     "require-dir": "^0.3.0",
     "run-sequence": "^1.0.2",
-    "typescript": "^1.5.3",
+    "typescript": "^1.6.2",
     "vulcanize": ">= 1.4.2",
     "web-component-tester": "^3.1.3"
   },

--- a/client-js/typings/polymer-ts/polymer-ts.d.ts
+++ b/client-js/typings/polymer-ts/polymer-ts.d.ts
@@ -1,5 +1,5 @@
 declare module polymer {
-    class PolymerBase {
+    class PolymerBase extends HTMLElement {
         $: any;
         $$: any;
         root: HTMLElement;
@@ -88,7 +88,7 @@ declare module polymer {
         type?: any;
         value?: any;
         reflectToAttribute?: boolean;
-        readonly?: boolean;
+        readOnly?: boolean;
         notify?: boolean;
         computed?: string;
         observer?: string;
@@ -96,6 +96,7 @@ declare module polymer {
     class Base extends polymer.PolymerBase implements polymer.Element {
         static create<T extends polymer.Base>(...args: any[]): T;
         static register(): void;
+        is: string;
     }
     function createEs6PolymerBase(): void;
     function prepareForRegistration(elementClass: Function): polymer.Element;
@@ -108,9 +109,9 @@ declare var Polymer: {
     (prototype: polymer.Element): FunctionConstructor;
     Class(prototype: polymer.Element): Function;
     dom: polymer.dom;
-    appendChild(node): HTMLElement;
-    insertBefore(node, beforeNode): HTMLElement;
-    removeChild(node): HTMLElement;
+    appendChild(node: HTMLElement): HTMLElement;
+    insertBefore(node: HTMLElement, beforeNode: HTMLElement): HTMLElement;
+    removeChild(node: HTMLElement): HTMLElement;
     updateStyles(): void;
     Base: any;
 };


### PR DESCRIPTION
Fixes #63, compilation problem with new version of typescript by also updating the gulp-typescript module used in the build. The main feature of interest in the polymer update is that elements properly extend HTMLElement, so they can be passed to DOM functions and typescript does not complain. HTMLElement already has a property called `dataset` that contains all `data-*` attributes, so we have to rename the attribute used to store the dataset name in our custom component.

When testing this, be sure to run `npm install` and `bower install` to pick up the library changes.
