### PR TITLE
Fix registry dir copy to work when copying dir into itself.

### DIFF
--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -77,17 +77,20 @@ export class LabradRegistry extends polymer.Base {
     //TODO increment selected key on tab
   }
 
-  repopulateList(resp: RegistryListing) {
-    this.selDir = null;
-    this.splice('dirs', 0, this.dirs.length);
-    this.splice('keys', 0, this.keys.length);
+  repopulateList(): Promise<void> {
+    return this.socket.dir({path: this.path}).then((resp) => {
+      this.selKey = null;
+      this.selDir = null;
+      this.splice('dirs', 0, this.dirs.length);
+      this.splice('keys', 0, this.keys.length);
 
-    for (var i in resp.dirs) {
-      this.push('dirs', {name: resp.dirs[i], url: this.createUrl(resp.path, resp.dirs[i])});
-    }
-    for (var j in resp.keys) {
-      this.push('keys', {name: resp.keys[j], value: resp.vals[j]});
-    }
+      for (var i in resp.dirs) {
+        this.push('dirs', {name: resp.dirs[i], url: this.createUrl(resp.path, resp.dirs[i])});
+      }
+      for (var j in resp.keys) {
+        this.push('keys', {name: resp.keys[j], value: resp.vals[j]});
+      }
+    });
   }
 
   createUrl(path: Array<string>, dir: string): string {
@@ -119,13 +122,9 @@ export class LabradRegistry extends polymer.Base {
   updateKey(event) {
     var selKey = event.detail.key;
     var newVal = event.detail.value;
-    this.socket.set({path: this.path, key: selKey, value: newVal}).then(
-      (resp) => {
-        this.repopulateList(resp);
-        this.selKey = null;
-      },
-      (reason) => this.handleError(reason)
-    );
+    this.socket.set({path: this.path, key: selKey, value: newVal})
+      .then(() => this.repopulateList())
+      .catch((reason) => this.handleError(reason));
   }
 
 
@@ -150,10 +149,9 @@ export class LabradRegistry extends polymer.Base {
     var newVal = this.$.newValueInput.value;
 
     if (newKey) {
-      this.socket.set({path: this.path, key: newKey, value: newVal}).then(
-        (resp) => this.repopulateList(resp),
-        (reason) => this.handleError(reason)
-      );
+      this.socket.set({path: this.path, key: newKey, value: newVal})
+        .then(() => this.repopulateList())
+        .catch((reason) => this.handleError(reason));
     }
     else {
       this.handleError('Cannot create key with empty name');
@@ -191,13 +189,9 @@ export class LabradRegistry extends polymer.Base {
   doEditValue() {
     var key = this.$.editValueDialog.keyName,
         newVal = this.$.editValueInput.value;
-    this.socket.set({path: this.path, key: key, value: newVal}).then(
-      (resp) => {
-        this.repopulateList(resp);
-        this.selKey = null;
-      },
-      (reason) => this.handleError(reason)
-    );
+    this.socket.set({path: this.path, key: key, value: newVal})
+      .then(() => this.repopulateList())
+      .catch((reason) => this.handleError(reason));
   }
 
   /**
@@ -218,10 +212,9 @@ export class LabradRegistry extends polymer.Base {
     var newFolder = this.$.newFolderInput.value;
 
     if (newFolder) {
-      this.socket.mkDir({path: this.path, dir: newFolder}).then(
-        (resp) => this.repopulateList(resp),
-        (reason) => this.handleError(reason)
-      );
+      this.socket.mkDir({path: this.path, dir: newFolder})
+        .then(() => this.repopulateList())
+        .catch((reason) => this.handleError(reason));
     }
     else {
       this.handleError('Cannot create folder with empty name');
@@ -250,16 +243,14 @@ export class LabradRegistry extends polymer.Base {
     var newPath = JSON.parse(this.$.copyPathInput.value);
 
     if (this.selectType === 'dir') {
-      this.socket.copyDir({path: this.path, dir: this.selDir, newPath: newPath, newDir: newName}).then(
-        (resp) => this.repopulateList(resp),
-        (reason) => this.handleError(reason)
-      );
+      this.socket.copyDir({path: this.path, dir: this.selDir, newPath: newPath, newDir: newName})
+        .then(() => this.repopulateList())
+        .catch((reason) => this.handleError(reason));
     }
     else if (this.selectType === 'key') {
-      this.socket.copy({path: this.path, key: this.selKey, newPath: newPath, newKey: newName}).then(
-        (resp) => this.repopulateList(resp),
-        (reason) => this.handleError(reason)
-      );
+      this.socket.copy({path: this.path, key: this.selKey, newPath: newPath, newKey: newName})
+        .then(() => this.repopulateList())
+        .catch((reason) => this.handleError(reason));
     }
   }
 
@@ -299,16 +290,14 @@ export class LabradRegistry extends polymer.Base {
     if (newName === null || newName === name) return;
     if (newName) {
       if (this.selectType === 'dir') {
-        this.socket.renameDir({path: this.path, dir: name, newDir: newName}).then(
-          (resp) => this.repopulateList(resp),
-          (reason) => this.handleError(reason)
-        );
+        this.socket.renameDir({path: this.path, dir: name, newDir: newName})
+          .then(() => this.repopulateList())
+          .catch((reason) => this.handleError(reason));
       }
       else if (this.selectType === 'key') {
-        this.socket.rename({path: this.path, key: name, newKey: newName}).then(
-          (resp) => this.repopulateList(resp),
-          (reason) => this.handleError(reason)
-        );
+        this.socket.rename({path: this.path, key: name, newKey: newName})
+          .then(() => this.repopulateList())
+          .catch((reason) => this.handleError(reason));
       }
     }
     else {
@@ -329,16 +318,14 @@ export class LabradRegistry extends polymer.Base {
    */
   doDelete() {
     if (this.selectType === 'dir') {
-      this.socket.rmDir({path: this.path, dir: this.selDir}).then(
-        (resp) => this.repopulateList(resp),
-        (reason) => this.handleError(reason)
-      );
+      this.socket.rmDir({path: this.path, dir: this.selDir})
+        .then(() => this.repopulateList())
+        .catch((reason) => this.handleError(reason));
     }
     else if (this.selectType === 'key') {
-      this.socket.del({path: this.path, key: this.selKey}).then(
-        (resp) => this.repopulateList(resp),
-        (reason) => this.handleError(reason)
-      );
+      this.socket.del({path: this.path, key: this.selKey})
+        .then(() => this.repopulateList())
+        .catch((reason) => this.handleError(reason));
     }
   }
 }

--- a/client-js/app/scripts/registry.ts
+++ b/client-js/app/scripts/registry.ts
@@ -9,19 +9,19 @@ export interface RegistryListing {
 
 export interface RegistryApi {
   dir(params: {path: Array<string>}): Promise<RegistryListing>;
-  set(params: {path: Array<string>; key: string; value: string}): Promise<RegistryListing>;
-  del(params: {path: Array<string>; key: string}): Promise<RegistryListing>;
+  set(params: {path: Array<string>; key: string; value: string}): Promise<void>;
+  del(params: {path: Array<string>; key: string}): Promise<void>;
 
-  mkDir(params: {path: Array<string>; dir: string}): Promise<RegistryListing>;
-  rmDir(params: {path: Array<string>; dir: string}): Promise<RegistryListing>;
+  mkDir(params: {path: Array<string>; dir: string}): Promise<void>;
+  rmDir(params: {path: Array<string>; dir: string}): Promise<void>;
 
-  rename(params: {path: Array<string>; key: string; newKey: string}): Promise<RegistryListing>;
-  copy(params: {path: Array<string>; key: string; newPath: Array<string>; newKey: string}): Promise<RegistryListing>;
-  move(params: {path: Array<string>; key: string; newPath: Array<string>; newKey: string}): Promise<RegistryListing>;
+  rename(params: {path: Array<string>; key: string; newKey: string}): Promise<void>;
+  copy(params: {path: Array<string>; key: string; newPath: Array<string>; newKey: string}): Promise<void>;
+  move(params: {path: Array<string>; key: string; newPath: Array<string>; newKey: string}): Promise<void>;
 
-  renameDir(params: {path: Array<string>; dir: string; newDir: string}): Promise<RegistryListing>;
-  copyDir(params: {path: Array<string>; dir: string; newPath: Array<string>; newDir: string}): Promise<RegistryListing>;
-  moveDir(params: {path: Array<string>; dir: string; newPath: Array<string>; newDir: string}): Promise<RegistryListing>;
+  renameDir(params: {path: Array<string>; dir: string; newDir: string}): Promise<void>;
+  copyDir(params: {path: Array<string>; dir: string; newPath: Array<string>; newDir: string}): Promise<void>;
+  moveDir(params: {path: Array<string>; dir: string; newPath: Array<string>; newDir: string}): Promise<void>;
 
   watch(params: {path: Array<string>}): Promise<void>;
   unwatch(params: {path: Array<string>}): Promise<void>;
@@ -36,35 +36,35 @@ export class RegistryServiceJsonRpc extends rpc.RpcService implements RegistryAp
   dir(params: {path: Array<string>}): Promise<RegistryListing> {
     return this.call<RegistryListing>('dir', params);
   }
-  set(params: {path: Array<string>; key: string; value: string}): Promise<RegistryListing> {
-    return this.call<RegistryListing>('set', params);
+  set(params: {path: Array<string>; key: string; value: string}): Promise<void> {
+    return this.call<void>('set', params);
   }
-  del(params: {path: Array<string>; key: string}): Promise<RegistryListing> {
-    return this.call<RegistryListing>('del', params);
+  del(params: {path: Array<string>; key: string}): Promise<void> {
+    return this.call<void>('del', params);
   }
-  mkDir(params: {path: Array<string>; dir: string}): Promise<RegistryListing> {
-    return this.call<RegistryListing>('mkDir', params);
+  mkDir(params: {path: Array<string>; dir: string}): Promise<void> {
+    return this.call<void>('mkDir', params);
   }
-  rmDir(params: {path: Array<string>; dir: string}): Promise<RegistryListing> {
-    return this.call<RegistryListing>('rmDir', params);
+  rmDir(params: {path: Array<string>; dir: string}): Promise<void> {
+    return this.call<void>('rmDir', params);
   }
-  rename(params: {path: Array<string>; key: string; newKey: string}): Promise<RegistryListing> {
-    return this.call<RegistryListing>('rename', params);
+  rename(params: {path: Array<string>; key: string; newKey: string}): Promise<void> {
+    return this.call<void>('rename', params);
   }
-  copy(params: {path: Array<string>; key: string; newPath: Array<string>; newKey: string}): Promise<RegistryListing> {
-    return this.call<RegistryListing>('copy', params);
+  copy(params: {path: Array<string>; key: string; newPath: Array<string>; newKey: string}): Promise<void> {
+    return this.call<void>('copy', params);
   }
-  move(params: {path: Array<string>; key: string; newPath: Array<string>; newKey: string}): Promise<RegistryListing> {
-    return this.call<RegistryListing>('move', params);
+  move(params: {path: Array<string>; key: string; newPath: Array<string>; newKey: string}): Promise<void> {
+    return this.call<void>('move', params);
   }
-  renameDir(params: {path: Array<string>; dir: string; newDir: string}): Promise<RegistryListing> {
-    return this.call<RegistryListing>('renameDir', params);
+  renameDir(params: {path: Array<string>; dir: string; newDir: string}): Promise<void> {
+    return this.call<void>('renameDir', params);
   }
-  copyDir(params: {path: Array<string>; dir: string; newPath: Array<string>; newDir: string}): Promise<RegistryListing> {
-    return this.call<RegistryListing>('copyDir', params);
+  copyDir(params: {path: Array<string>; dir: string; newPath: Array<string>; newDir: string}): Promise<void> {
+    return this.call<void>('copyDir', params);
   }
-  moveDir(params: {path: Array<string>; dir: string; newPath: Array<string>; newDir: string}): Promise<RegistryListing> {
-    return this.call<RegistryListing>('moveDir', params);
+  moveDir(params: {path: Array<string>; dir: string; newPath: Array<string>; newDir: string}): Promise<void> {
+    return this.call<void>('moveDir', params);
   }
 
   watch(params: {path: Array<string>}): Promise<void> {


### PR DESCRIPTION
Previously the directory copy operation would create the destination directory before getting a listing of the source directory. As a result, copying a directory into itself led to an infinite recursion. If we instead get the source listing first, then the problem goes away and the copying a directory into itself is a perfectly well-behaved operation.

We also change the way the registry api methods work so that only the `dir` call returns a registry listing, and the others return nothing. The client must then request a new directory listing after it makes another call to manipulate the registry. There are a few reasons for doing this. First, in operations such as copy and move, the listing returned may not actually correspond to the directory the page is showing; sometimes we may be viewing the source directory, other times the destination directory (for example in a copy or move triggered by drag and drop) or some other directory entirely (e.g. in drag and drop from another window when we then edit the destination). It's best to just let the client ask for what it wants. Second, if in the future we decide to batch operations (e.g. to edit multiple keys or something like that), then we want to make sure we don't transfer lots of listing data unnecessarily. Finally, once we implement events so that the client gets notified of registry changes in a directory, we won't need these directory listings at all.

Fixes #73 
