### PR TITLE
Add PromiseInput class which serves as input to Promise chain.

### DIFF
--- a/client-js/app/scripts/obligation.ts
+++ b/client-js/app/scripts/obligation.ts
@@ -1,0 +1,38 @@
+/**
+ * Obligation is the input side complement of Promise; while Promise provides a
+ * way to create chains of asynchronous callbacks, Obligation is the input that
+ * lets us send a value or error in to the beginning of the callback chain.
+ *
+ * The name is meant to evoke a scenario in which Alice gives to Bob a promise
+ * that she will deliver a value. We then say that Alice has an obligation to
+ * either deliver a value as promised or else explain why she failed to do so.
+ * An Obligation contains two methods `resolve` and `reject` which correspond
+ * respectively to these two cases, delivering a value or failing with an error.
+ *
+ * In the standard ES6 Promise API, resolve and reject functions are only
+ * accessible as arguments passed in to the executor function which we pass to
+ * the Promise constructor. However, in many cases we'd like to call these
+ * functions from outside the constructor; Obligation makes this possible. This
+ * is especially useful in situations where we need to connect callback-based
+ * code with Promise-based code.
+ *
+ * Compare the scala.concurrent library, which properly separates the input and
+ * output sides of an asynchronous callback chain into two classes:
+ * scala.concurrent.Promise is the input side (equivalent to Obligation here)
+ * and scala.concurrent.Future is the output side (equivalent to Promise here).
+ */
+export interface Obligation<R> {
+  resolve: (value?: R | Promise<R>) => void;
+  reject: (error: any) => void
+}
+
+/**
+ * Create an Obligation/Promise pair with the given result type.
+ */
+export function obligate<R>(): { obligation: Obligation<R>, promise: Promise<R> } {
+  var obligation: Obligation<R>;
+  var promise = new Promise<R>((resolve, reject) => {
+    obligation = { resolve: resolve, reject: reject };
+  });
+  return { obligation: obligation, promise: promise };
+}

--- a/client-js/test/spec/main.ts
+++ b/client-js/test/spec/main.ts
@@ -1,4 +1,5 @@
 // Import tests modules to run them.
 // As new tests are created, be sure to add them here.
 
+import './obligation-spec';
 import './ts-test-spec';

--- a/client-js/test/spec/obligation-spec.ts
+++ b/client-js/test/spec/obligation-spec.ts
@@ -1,0 +1,24 @@
+import {Obligation, obligate} from '../app/scripts/obligation';
+
+describe('Obligation', function() {
+
+  it('resolves promise when resolve is called', (done) => {
+    var { obligation, promise } = obligate<string>();
+    promise.then((msg) => {
+      expect(msg).toEqual('foo');
+      done();
+    });
+    obligation.resolve('foo');
+  });
+
+  it('rejects promise when reject is called', (done) => {
+    var { obligation, promise } = obligate<string>();
+    promise.catch((err) => {
+      expect(err.message).toEqual('bar');
+      done();
+    });
+    obligation.reject(new Error('bar'));
+  });
+
+});
+


### PR DESCRIPTION
In several places, we were pulling out the resolve and reject callbacks from a newly-created promise and storing them to be called later when we have a value or error with which to complete the promise. This adds a `PromiseInput` class to formalize this pattern.

I'm not too sure about the name, so would be happy if people have other suggestions. I thought about `Completable` which conveys the notion that once we resolve or reject, the operation is complete and we can't resolve or reject again. But it's also nice to have the name reflect that this class is closely related to `Promise`. As always, names are hard.
