### PR TITLE
Fix jasmine version in package.json

### DIFF
--- a/client-js/package.json
+++ b/client-js/package.json
@@ -30,7 +30,7 @@
     "gulp-useref": "^1.1.2",
     "gulp-util": "^3.0.5",
     "gulp-vulcanize": "^6.0.0",
-    "jasmine": "2.3.4",
+    "jasmine": "2.4.1",
     "jshint-stylish": "^2.0.0",
     "jspm": "^0.15.7",
     "merge-stream": "^0.1.7",


### PR DESCRIPTION
Running `npm install` on master fails because the jasmine version is not available:

```
$ npm install
npm WARN package.json labrad-browser@0.0.0 No description
npm WARN package.json labrad-browser@0.0.0 No repository field.
npm WARN package.json labrad-browser@0.0.0 No README data
npm WARN package.json labrad-browser@0.0.0 No license field.
npm ERR! Darwin 15.0.0
npm ERR! argv "node" "/usr/local/bin/npm" "install"
npm ERR! node v0.12.4
npm ERR! npm  v2.10.1

npm ERR! version not found: jasmine@2.3.4
npm ERR! 
npm ERR! If you need help, you may report this error at:
npm ERR!     <https://github.com/npm/npm/issues>
```

As far as I can tell from the jasmine repo there never was a version 2.3.4 (https://github.com/jasmine/jasmine-npm/releases). In any case, updating the version number seems to work.

@joshmutus 
