### PR TITLE
Add main test entry point module which can import other tests

### DIFF
--- a/client-js/gulpfile.js
+++ b/client-js/gulpfile.js
@@ -101,7 +101,7 @@ gulp.task('bundle', ['compile-ts'], function(cb) {
  * configurations are found in /config.js 
  */
 gulp.task('bundle-test', ['compile-test','compile-ts'], function(cb) {
-  var cmd = 'node_modules/.bin/jspm bundle-sfx spec/ts-test-spec .tmp/testing/spec-bundle.js --skip-source-maps';
+  var cmd = 'node_modules/.bin/jspm bundle-sfx spec/main .tmp/testing/spec-bundle.js --skip-source-maps';
   exec(cmd, function (err, stdout, stderr) {
     console.log(stdout);
     console.log(stderr);

--- a/client-js/test/spec/main.ts
+++ b/client-js/test/spec/main.ts
@@ -1,0 +1,4 @@
+// Import tests modules to run them.
+// As new tests are created, be sure to add them here.
+
+import './ts-test-spec';


### PR DESCRIPTION
This way we can define tests in multiple files and just add a line to the test main module to import each file.
