### PR TITLE
Fix y-axis label on 2D plots

### DIFF
--- a/client-js/app/scripts/app.ts
+++ b/client-js/app/scripts/app.ts
@@ -385,9 +385,13 @@ window.addEventListener('WebComponentsReady', () => {
       if (info.independents.length <= 2) {
         let plot = <Plot> Plot.create();
         plot.setAttribute('class', 'flex');
-        plot.xLabel = info.independents[0];
-        plot.yLabel = info.dependents[0];
         plot.numIndeps = info.independents.length;
+        plot.xLabel = info.independents[0];
+        if (plot.numIndeps == 1) {
+          plot.yLabel = info.dependents[0];
+        } else {
+          plot.yLabel = info.independents[1];
+        }
         this.plot = plot;
         elem = plot;
       } else {


### PR DESCRIPTION
We have to choose the y-axis label differently for 2D versus 1D plots. This was broken when we consolidated the 1- and 2-D plotting code.
