### PR TITLE
Update jsonrpc macro to allow any number of params and default values

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,8 @@ lazy val jsonrpc = project.in(file("jsonrpc"))
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-reflect" % scalaVersion.value,
       "com.typesafe.play" %% "play-json" % "2.4.0",
-      "net.maffoo" %% "jsonquote-play" % "0.3.0"
+      "net.maffoo" %% "jsonquote-play" % "0.3.0",
+      "org.scalatest" %% "scalatest" % "2.2.4" % "test"
     )
   )
 

--- a/client-js/app/scripts/datavault.ts
+++ b/client-js/app/scripts/datavault.ts
@@ -71,7 +71,6 @@ export class DataVaultService extends rpc.RpcService implements DataVaultApi {
   }
 
   dataStreamGet(params: {token: string; limit?: number}): Promise<Array<Array<number>>> {
-    params.limit = params.limit || 1000;
     return this.call<Array<Array<number>>>('dataStreamGet', params);
   }
 

--- a/jsonrpc/src/main/scala/org/labrad/browser/jsonrpc/JsonRpc.scala
+++ b/jsonrpc/src/main/scala/org/labrad/browser/jsonrpc/JsonRpc.scala
@@ -408,13 +408,9 @@ object JsonRpc {
         val defaultName = methodName + "$default$" + (i+1)
         val default = defaultMethods.find(m => symbolName(m) == defaultName) match {
           case Some(m) =>
-            val invokeDefault = Apply(
-              Select(
-                inst,
-                TermName(defaultName)
-              ),
-              List()
-            )
+            // Default methods are defined without parens,
+            // so we can invoke them just by selecting.
+            val invokeDefault = Select(inst, TermName(defaultName))
             q"_root_.scala.Some(() => $invokeDefault)"
 
           case None => q"_root_.scala.None"

--- a/jsonrpc/src/test/scala/org/labrad/browser/jsonrpc/JsonRpcTest.scala
+++ b/jsonrpc/src/test/scala/org/labrad/browser/jsonrpc/JsonRpcTest.scala
@@ -1,0 +1,21 @@
+package org.labrad.browser.jsonrpc
+
+import org.labrad.browser.jsonrpc._
+import org.scalatest.FunSuite
+import play.api.libs.json._
+import scala.concurrent.Future
+
+class TestApi {
+  def foo(a: Int, b: Boolean = true): Unit = {
+    ()
+  }
+}
+
+class JsonRpcTest extends FunSuite {
+  test("can route to methods with default values") {
+    val testApi = new TestApi
+    val routes = JsonRpc.routes("""
+      CALL  test.foo  testApi.foo
+    """)
+  }
+}

--- a/server/src/main/scala/org/labrad/browser/VaultApi.scala
+++ b/server/src/main/scala/org/labrad/browser/VaultApi.scala
@@ -235,8 +235,7 @@ class VaultApi(cxn: LabradConnection, client: VaultClientApi)(implicit ec: Execu
     p.send()
   }
 
-  // TODO: JsonRpc does not work with default values of type Int
-  def dataStreamGet(token: String, limit: Int): Future[Array[Array[Double]]] = {
+  def dataStreamGet(token: String, limit: Int = 2000): Future[Array[Array[Double]]] = {
     val context = dataStreamsByToken(token)
     new VaultServerProxy(cxn.get, context = context).get(limit, startOver = false)
   }


### PR DESCRIPTION
Previously, we had separate cases spelled out explicitly for each different number of parameters expected by the scala method being called. But, by taking advantage of the unhygienic nature of quasiquote macros, we can simplify this. In particular, the ASTs to extract each argument refer to a term called "params" that is not defined until later when we put these ASTs inside a macros that defines the function invoked with the jsonrpc params.

Also fix the handling of default parameters, so that we can correctly dispatch to methods with default parameter values.
