### PR TITLE
Display error message and reconnect after connection loss

### DIFF
--- a/client-js/app/elements/labrad-app.html
+++ b/client-js/app/elements/labrad-app.html
@@ -127,5 +127,15 @@
         <paper-button id="loginButton">Login</paper-button>
       </div>
     </paper-dialog>
+
+    <paper-dialog id="errorDialog" modal>
+      <h1>Lost connection to Labrad</h1>
+      <div>
+        <span>{{connectionError}}</span>
+      </div>
+      <div>
+        Attempting to reconnect.
+      </div>
+    </paper-dialog>
   </template>
 </dom-module>

--- a/client-js/app/elements/labrad-app.ts
+++ b/client-js/app/elements/labrad-app.ts
@@ -15,6 +15,9 @@ export class LabradApp extends polymer.Base {
   @property({type: String})
   loginError: string;
 
+  @property({type: String})
+  connectionError: string;
+
   ready() {
     // Ensure the drawer is hidden on desktop/tablet
     this.$.drawerPanel.forceNarrow = true;

--- a/client-js/app/scripts/app.ts
+++ b/client-js/app/scripts/app.ts
@@ -70,7 +70,25 @@ window.addEventListener('WebComponentsReady', () => {
   var apiUrl = (window['apiHost'] || relativeWebSocketUrl()) + "/api/socket";
 
   var socket = new rpc.JsonRpcSocket(apiUrl);
+  socket.connectionClosed.add((event) => {
+    app.connectionError = "WebSocket connection closed.";
+    app.$.errorDialog.open();
+    setTimeout(() => {
+      console.log('reloading!');
+      location.reload();
+    }, 10000);
+  });
+
   var mgr = new manager.ManagerServiceJsonRpc(socket);
+  mgr.disconnected.add((msg) => {
+    app.connectionError = "Manager connection closed.";
+    app.$.errorDialog.open();
+    setTimeout(() => {
+      console.log('reloading!');
+      location.reload();
+    }, 10000);
+  });
+
   var reg = new registry.RegistryServiceJsonRpc(socket);
   var dv = new datavault.DataVaultService(socket);
   var node = new nodeApi.NodeService(socket);


### PR DESCRIPTION
If we lose the websocket connection to the web server, or the server loses its connection to the labrad manager, pop up a dialog box informing the user and attempt to reconnect after some delay.
