### PR TITLE
156 long keys

### DIFF
--- a/client-js/app/elements/elements.html
+++ b/client-js/app/elements/elements.html
@@ -14,6 +14,7 @@
 <link rel="import" href="../bower_components/paper-tabs/paper-tabs.html">
 <link rel="import" href="../bower_components/paper-drawer-panel/paper-drawer-panel.html">
 <link rel="import" href="../bower_components/paper-dialog/paper-dialog.html">
+<link rel="import" href="../bower_components/paper-dialog-scrollable/paper-dialog-scrollable.html">
 <link rel="import" href="../bower_components/paper-header-panel/paper-header-panel.html">
 <link rel="import" href="../bower_components/paper-icon-button/paper-icon-button.html">
 <link rel="import" href="../bower_components/paper-input/paper-input.html">

--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -199,10 +199,12 @@
 
     <paper-dialog id="newKeyDialog" modal>
       <h1>Create new key</h1>
-      <form>
-        <paper-input id="newKeyInput" label="Key"></paper-input>
-        <paper-textarea id="newValueInput" label="Value"></paper-textarea>
-      </form>
+      <paper-dialog-scrollable>
+        <form>
+          <paper-input id="newKeyInput" label="Key"></paper-input>
+          <paper-textarea id="newValueInput" label="Value"></paper-textarea>
+        </form>
+      </paper-dialog-scrollable>
       <div class="buttons"> 
         <paper-button on-click="doNewKey" dialog-confirm>OK</paper-button>
         <paper-button dialog-dismiss>CANCEL</paper-button>
@@ -211,9 +213,11 @@
 
     <paper-dialog id="editValueDialog" modal>
       <h1>Edit: <span>{{selectedItem}}</span></h1>
-      <form>
-        <paper-textarea id="editValueInput" label="Value"></paper-textarea>
-      </form>
+      <paper-dialog-scrollable>
+        <form>
+          <paper-textarea id="editValueInput" label="Value"></paper-textarea>
+        </form>
+      </paper-dialog-scrollable>
       <div class="buttons">
         <paper-button on-click="doEditValue" dialog-confirm autofocus>OK</paper-button>
         <paper-button dialog-dismiss>CANCEL</paper-button>


### PR DESCRIPTION
This is based on the other pull request. Requires a `bower install` to get the `<paper-dialog-scrollable>` if you don't already have it.

Fixes #156 
