### PR TITLE
Use base tag in index.html to allow for relative urls

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,7 @@ lazy val server = project.in(file("server"))
 
     libraryDependencies ++= Seq(
       "org.scala-lang.modules" %% "scala-async" % "0.9.2",
+      "org.jsoup" % "jsoup" % "1.9.2",
       "org.labrad" %% "scalabrad" % "0.6.2"
     ),
 

--- a/client-js/app/index.html
+++ b/client-js/app/index.html
@@ -7,11 +7,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>LabRAD</title>
 
+  <!-- Resolve relative URLs against the root path, not the current route path -->
+  <base href="/">
+
   <!-- Chrome for Android theme color -->
   <meta name="theme-color" content="#303F9F">
 
   <!-- Web Application Manifest -->
-  <link rel="manifest" href="/manifest.json">
+  <link rel="manifest" href="manifest.json">
 
   <!-- Tile color for Win8 -->
   <meta name="msapplication-TileColor" content="#3372DF">
@@ -19,20 +22,20 @@
   <!-- Add to homescreen for Chrome on Android -->
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="application-name" content="LabRAD">
-  <link rel="icon" href="/images/labrad.png">
+  <link rel="icon" href="images/labrad.png">
 
   <!-- Add to homescreen for Safari on iOS -->
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="LabRAD">
-  <link rel="apple-touch-icon" href="/images/touch/apple-touch-icon.png">
+  <link rel="apple-touch-icon" href="images/touch/apple-touch-icon.png">
 
   <!-- Tile icon for Win8 (144x144) -->
-  <meta name="msapplication-TileImage" content="/images/touch/ms-touch-icon-144x144-precomposed.png">
+  <meta name="msapplication-TileImage" content="images/touch/ms-touch-icon-144x144-precomposed.png">
 
-  <link rel="stylesheet" href="/styles/main.css">
-  <script src="/bower_components/webcomponentsjs/webcomponents-lite.js"></script>
-  <link rel="import" href="/elements/elements.html">
+  <link rel="stylesheet" href="styles/main.css">
+  <script src="bower_components/webcomponentsjs/webcomponents-lite.js"></script>
+  <link rel="import" href="elements/elements.html">
 
   <!-- Dev mode configuration. The following comment is a placeholder
        that gets replaced in dev mode by an inline script that configures
@@ -40,14 +43,9 @@
        websocket api connections should be made. Comments are stripped
        when we built the dist version, so this has no effect in prod. -->
   <!-- DEV_MODE_CONFIG -->
-
-  <script type="application/javascript">
-    window['org.labrad.urlPrefix'] = "__LABRAD_URL_PREFIX__";
-    window['org.labrad.managers'] = "__LABRAD_MANAGERS__";
-  </script>
 </head>
 
 <body unresolved class="fullbleed layout vertical">
-  <script src="/scripts/bundle.js"></script>
+  <script src="scripts/bundle.js"></script>
 </body>
 </html>

--- a/client-js/app/scripts/app.ts
+++ b/client-js/app/scripts/app.ts
@@ -93,9 +93,21 @@ window.addEventListener('WebComponentsReady', () => {
   LabeledPlot.register();
 
   var prefix = "";
-  var prefixElem = document.querySelector("base");
-  if (prefixElem !== null) {
-    prefix = prefixElem.getAttribute("href");
+  var baseElem = document.querySelector("base");
+  if (baseElem !== null) {
+    var href = baseElem.getAttribute("href");
+
+    // If href does not end with a trailing slash, remove the last segment.
+    // Resolving relative URLs against /a/b/c.html is the same as against /a/b/
+    // and we don't want c.html in the prefix.
+    if (!href.endsWith("/")) {
+      var segments = href.split("/");
+      segments[segments.length - 1] = "";
+      href = segments.join("/");
+    }
+
+    // Strip trailing slash, since routes have leading slash already.
+    prefix = href.substring(0, href.length - 1);
   }
   console.log('urlPrefix', prefix);
 

--- a/client-js/app/scripts/app.ts
+++ b/client-js/app/scripts/app.ts
@@ -92,16 +92,12 @@ window.addEventListener('WebComponentsReady', () => {
   Plot.register();
   LabeledPlot.register();
 
-  var prefix = window['org.labrad.urlPrefix'];
-  if (prefix == "__LABRAD_URL_PREFIX__") {
-    prefix = "";
+  var prefix = "";
+  var prefixElem = document.querySelector("base");
+  if (prefixElem !== null) {
+    prefix = prefixElem.getAttribute("href");
   }
   console.log('urlPrefix', prefix);
-
-  var managers = window['org.labrad.managers'];
-  if (managers == "__LABRAD_MANAGERS__") {
-    managers = [];
-  }
 
   var body = document.querySelector('body');
   body.removeAttribute('unresolved');

--- a/server/src/main/scala/org/labrad/browser/WebServer.scala
+++ b/server/src/main/scala/org/labrad/browser/WebServer.scala
@@ -11,6 +11,7 @@ import io.netty.handler.logging.{LogLevel, LoggingHandler}
 import java.nio.charset.StandardCharsets.UTF_8
 import org.clapper.argot._
 import org.clapper.argot.ArgotConverters._
+import org.jsoup.Jsoup
 import org.labrad.util.Util
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{Try, Success, Failure}
@@ -113,8 +114,12 @@ class WebServer(config: WebServerConfig) {
       case None => (path, bytes)
       case Some(prefix) =>
         val appString = new String(bytes, UTF_8)
-        val newAppString = appString.replace("__LABRAD_URL_PREFIX__", prefix)
-        (path, newAppString.getBytes(UTF_8))
+        val appDom = Jsoup.parse(appString)
+
+        // Change the page base url to match urlPrefix
+        appDom.getElementsByTag("base").first().attr("href", prefix)
+
+        (path, appDom.toString.getBytes(UTF_8))
     }
   }
   val appFunc = () => staticHandler.makeResponse(appPath, appBytes)


### PR DESCRIPTION
We send index.html to the browser to bootstrap the app no matter what route within the app the user loads. Hence, to use relative urls we must update the base against which urls in the index page are resolved to use the root path where the app is hosted, not the route from which the page was served.

On the server, we modify the base href appropriately before serving the page by manipulating the page DOM (previously this was done by injecting javascript, but the DOM manipulation is much cleaner). We also fix up the way this is handled on the client-side to be consistent with how the browser itself resolves relative URLs.
