### PR TITLE
Show server and client versions in client-side UI

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,11 @@
 lazy val commonSettings = Seq(
-  version := "1.0.1",
+  useJGit,
+  git.useGitDescribe := true,
   scalaVersion := "2.11.7",
   resolvers += "bintray" at "http://jcenter.bintray.com"
 )
+
+enablePlugins(GitVersioning)
 
 lazy val jsonrpc = project.in(file("jsonrpc"))
   .settings(commonSettings)
@@ -36,6 +39,17 @@ lazy val server = project.in(file("server"))
     fork in run := true,
     connectInput in run := true,
     javaOptions += "-Dorg.labrad.stopOnEOF=true",
+
+    // add a resource generator that saves the git version in a file
+    resourceGenerators in Compile += Def.task {
+      val versionStr = version.value
+      val s = streams.value
+      s.log.info(s"git version: $versionStr")
+      val dstDir = (resourceManaged in Compile).value
+      val dstFile = dstDir / "org" / "labrad" / "browser" / "version.txt"
+      IO.write(dstFile, versionStr)
+      Seq(dstFile)
+    }.taskValue,
 
     // add a resource generator that copies compiled files from the client project
     resourceGenerators in Compile += Def.task {

--- a/client-js/app/elements/labrad-app.html
+++ b/client-js/app/elements/labrad-app.html
@@ -60,6 +60,17 @@
       direction: rtl;
     }
 
+    #tech-info {
+      margin: 20px;
+    }
+    #tech-info h1 {
+      font-size: 16px;
+    }
+    #tech-info p {
+      font-size: 12px;
+      font-family: monospace;
+    }
+
   </style>
   <template>
     <paper-drawer-panel id="drawerPanel" force-narrow disable-edge-swipe>
@@ -91,6 +102,11 @@
             <span>Grapher</span>
           </a>
         </paper-menu>
+
+        <div id="tech-info">
+          <h1>Technical Info</h1>
+          <p>server: <span>{{serverVersion}}</span></p>
+        </div>
       </div>
 
       <paper-header-panel main mode="standard">

--- a/client-js/app/elements/labrad-app.html
+++ b/client-js/app/elements/labrad-app.html
@@ -105,6 +105,7 @@
 
         <div id="tech-info">
           <h1>Technical Info</h1>
+          <p>client: <span>{{clientVersion}}</span></p>
           <p>server: <span>{{serverVersion}}</span></p>
         </div>
       </div>

--- a/client-js/app/elements/labrad-app.ts
+++ b/client-js/app/elements/labrad-app.ts
@@ -2,6 +2,9 @@ import {Places} from '../scripts/places';
 
 @component('labrad-app')
 export class LabradApp extends polymer.Base {
+  @property({type: String, value: '<unknwon>'})
+  serverVersion: string;
+
   @property({type: String, value: ''})
   host: string;
 

--- a/client-js/app/elements/labrad-app.ts
+++ b/client-js/app/elements/labrad-app.ts
@@ -3,6 +3,9 @@ import {Places} from '../scripts/places';
 @component('labrad-app')
 export class LabradApp extends polymer.Base {
   @property({type: String, value: '<unknwon>'})
+  clientVersion: string;
+
+  @property({type: String, value: '<unknwon>'})
   serverVersion: string;
 
   @property({type: String, value: ''})

--- a/client-js/app/scripts/app.ts
+++ b/client-js/app/scripts/app.ts
@@ -111,16 +111,25 @@ window.addEventListener('WebComponentsReady', () => {
   }
   console.log('urlPrefix', prefix);
 
-  function getMeta<A>(name: string, fallback: A): A {
+  function getMeta(name: string): string {
     var elem = document.querySelector(`meta[name=${name}]`);
     if (elem === null) {
-      return fallback;
+      return null;
     }
-    return <A>JSON.parse(elem.getAttribute("content"));
+    return elem.getAttribute("content");
   }
 
-  var redirectGrapher = getMeta<boolean>("labrad-redirectGrapher", false);
-  var redirectRegistry = getMeta<boolean>("labrad-redirectRegistry", false);
+  function getMetaJSON<A>(name: string, fallback: A): A {
+    var value = getMeta(name);
+    if (value === null) {
+      return fallback;
+    }
+    return <A>JSON.parse(value);
+  }
+
+  var clientVersion = getMeta("labrad-clientVersion");
+  var redirectGrapher = getMetaJSON<boolean>("labrad-redirectGrapher", false);
+  var redirectRegistry = getMetaJSON<boolean>("labrad-redirectRegistry", false);
 
   var body = document.querySelector('body');
   body.removeAttribute('unresolved');
@@ -129,6 +138,7 @@ window.addEventListener('WebComponentsReady', () => {
   });
 
   var app = <LabradApp> LabradApp.create();
+  app.clientVersion = clientVersion;
   body.appendChild(app);
 
   // Construct a websocket url relative to this page based on window.location
@@ -144,7 +154,7 @@ window.addEventListener('WebComponentsReady', () => {
   // Get the url for the api backend websocket connection.
   // If the apiHost variable has been set globally, use that,
   // otherwise construct a url relative to the page host.
-  var apiUrl = (window['apiHost'] || relativeWebSocketUrl()) + prefix + "/api/socket";
+  var apiUrl = (getMeta("labrad-apiHost") || relativeWebSocketUrl()) + prefix + "/api/socket";
 
   // The current activity, which encapsulates the current URL and the UI
   // rendered for that URL.

--- a/client-js/app/scripts/app.ts
+++ b/client-js/app/scripts/app.ts
@@ -420,6 +420,9 @@ window.addEventListener('WebComponentsReady', () => {
 
     var mgr = new manager.ManagerServiceJsonRpc(socket);
     if (topLevel) {
+      mgr.version().then((version) => {
+        app.serverVersion = version;
+      });
       mgr.disconnected.add((msg) => {
         reconnect("Manager connection closed.");
       });

--- a/client-js/app/scripts/manager.ts
+++ b/client-js/app/scripts/manager.ts
@@ -42,6 +42,7 @@ export interface ServerDisconnectMessage { name: string; }
 export interface ManagerApi {
   login(params: {username: string; password: string, host: string}): Promise<void>;
   ping(): Promise<void>;
+  version(): Promise<string>;
   connections(): Promise<Array<ConnectionInfo>>;
   connectionClose(id: number): Promise<string>;
   serverInfo(name: String): Promise<ServerInfo>;
@@ -73,6 +74,10 @@ export class ManagerServiceJsonRpc extends rpc.RpcService implements ManagerApi 
 
   ping(): Promise<void> {
     return this.call<void>("ping", []);
+  }
+
+  version(): Promise<string> {
+    return this.call<string>("version", []);
   }
 
   connections(): Promise<Array<ConnectionInfo>> {

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -5,6 +5,7 @@
   "devDependencies": {
     "browser-sync": "^2.6.4",
     "del": "^1.1.1",
+    "git-describe": "^3.0.0",
     "glob": "^5.0.6",
     "gulp": "^3.8.5",
     "gulp-autoprefixer": "^2.1.0",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,6 @@ name := "scalabrad-web"
 
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "3.0.0")
-
 addSbtPlugin("org.xerial.sbt" % "sbt-pack" % "0.6.5")  // for sbt-0.13.x or higher

--- a/server/src/main/scala/org/labrad/browser/ApiBackend.scala
+++ b/server/src/main/scala/org/labrad/browser/ApiBackend.scala
@@ -61,6 +61,7 @@ class ApiBackend(config: LabradConnectionConfig)(implicit ec: ExecutionContext) 
     routes = JsonRpc.routes("""
       CALL  org.labrad.manager.login  cxn.login
       CALL                    .ping      .ping
+      CALL                    .version   .version
 
       CALL  org.labrad.datavault.dir          datavaultApi.dir
       CALL                      .datasetInfo              .datasetInfo

--- a/server/src/main/scala/org/labrad/browser/LabradConnection.scala
+++ b/server/src/main/scala/org/labrad/browser/LabradConnection.scala
@@ -9,7 +9,10 @@ import scala.collection.mutable
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration._
 
-case class LabradConnectionConfig(hosts: Map[String, String])
+case class LabradConnectionConfig(
+  hosts: Map[String, String],
+  suffix: Option[String]
+)
 
 object LabradConnection {
   val timer = new Timer(true)
@@ -45,7 +48,13 @@ class LabradConnection(
   }
 
   def login(username: String, password: String, host: String/* = ""*/): Unit = {
-    val hostname = config.hosts.get(host).getOrElse(host)
+    val hostname = config.hosts.get(host).getOrElse {
+      if (!host.isEmpty && !host.contains(".")) {
+        host + config.suffix.getOrElse("")
+      } else {
+        host
+      }
+    }
     if (hostname == host) {
       println(s"logging in to host: '$host'")
     } else {

--- a/server/src/main/scala/org/labrad/browser/LabradConnection.scala
+++ b/server/src/main/scala/org/labrad/browser/LabradConnection.scala
@@ -72,6 +72,10 @@ class LabradConnection(
   def ping(): Unit = {
   }
 
+  def version(): String = {
+    WebServer.VERSION
+  }
+
   def get: Connection = {
     cxnOpt.getOrElse { sys.error("not connected") }
   }

--- a/server/src/main/scala/org/labrad/browser/WebServer.scala
+++ b/server/src/main/scala/org/labrad/browser/WebServer.scala
@@ -155,6 +155,10 @@ class WebServer(config: WebServerConfig) {
     head.appendElement("meta").attr("name", "labrad-redirectRegistry")
                               .attr("content", config.redirectRegistry.toString)
 
+    // Add version info to page
+    head.appendElement("meta").attr("name", "labrad-serverVersion")
+                              .attr("content", WebServer.VERSION)
+
     (path, appDom.toString.getBytes(UTF_8))
   }
   val appFunc = () => staticHandler.makeResponse(appPath, appBytes)
@@ -194,6 +198,11 @@ class WebServer(config: WebServerConfig) {
 }
 
 object WebServer {
+  val VERSION = {
+    val url = getClass.getResource("/org/labrad/browser/version.txt")
+    scala.io.Source.fromURL(url).mkString
+  }
+
   def main(args: Array[String]): Unit = {
     val config = WebServerConfig.fromCommandLine(args) match {
       case Success(config) => config


### PR DESCRIPTION
The server and client versions are pulled from the state of the git tree when the client and server are built, using the sbt-git plugin on the server side and the git-describe library in gulp for the client. Both of these give a string describing the version that is based on git tags and the state of the tree. If you build a version tagged as `1.0.1`, the version will just be `1.0.1`. Otherwise the version will show the number of commits beyond a given tag, so if we build master several commits after that tagged version, the version string will be, say, `1.0.1-7-g0c80392` to indicate that we are 7 commits past the `1.0.1` tag at revision `0c80392`. In addition, if the local tree has uncommitted changes when things are built, then we'd see that tacked on the end as well: `1.0.1-7-g0c80392-dirty`. We also change the sbt build to use this when producing archives, so we don't need to update version numbers in the code, just use git tags.

Note that I've included two somewhat unrelated changes to add some options for specifying a manager host suffix and optionally redirecting the grapher and registry routes when using a single grapher or registry with multiple managers as we tend to do. I included them because they were developed in that order and so it was easier to put them all up rather than disentangle. I can pull them apart if desired, but it shouldn't be too bad to review the individual commits.

@joshmutus  
