### PR TITLE
Fix d3 package organization in package.json

### DIFF
--- a/client-js/package.json
+++ b/client-js/package.json
@@ -48,7 +48,7 @@
   "jspm": {
     "directories": {},
     "dependencies": {
-      "d3": "github:mbostock/d3@^3.5.6",
+      "d3": "github:d3/d3@^3.5.6",
       "page": "npm:page@^1.6.3"
     },
     "devDependencies": {


### PR DESCRIPTION
d3 has apparently changed github organizations. jspm changes this when running a clean `jspm install` so just want to commit the change.
