### PR TITLE
Add expected fields to package.json to avoid npm warnings.

### DIFF
--- a/client-js/README.md
+++ b/client-js/README.md
@@ -1,0 +1,4 @@
+# Client code for scalabrad-web
+
+See the main README in the repo root. This file is just here to keep npm happy.
+

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,10 @@
 {
   "name": "labrad-browser",
   "version": "0.0.0",
+  "description": "A web interface for labrad",
+  "repository": "labrad/scalabrad-web",
+  "license": "MIT",
+
   "dependencies": {},
   "devDependencies": {
     "browser-sync": "^2.6.4",


### PR DESCRIPTION
When running `npm` we get warning like these:

```
npm WARN package.json labrad-browser@0.0.0 No description
npm WARN package.json labrad-browser@0.0.0 No repository field.
npm WARN package.json labrad-browser@0.0.0 No README data
npm WARN package.json labrad-browser@0.0.0 No license field.
```

We add the necessary fields and a `README` in the `client-js/` folder to silence these warnings.
