### PR TITLE
Reduce the amount of output written to the console log.

### DIFF
--- a/client-js/app/elements/labrad-nodes.ts
+++ b/client-js/app/elements/labrad-nodes.ts
@@ -48,19 +48,19 @@ export class LabradInstanceController extends polymer.Base {
 
   @listen('start.click')
   doStart() {
-    console.log(`start: server='${this.name}', node='${this.node}'`);
+    console.info(`Start: server='${this.name}', node='${this.node}'`);
     this.api.startServer({node: this.node, server: this.name});
   }
 
   @listen('stop.click')
   doStop() {
-    console.log(`stop: server='${this.name}', node='${this.node}'`);
+    console.info(`Stop: server='${this.name}', node='${this.node}'`);
     this.api.stopServer({node: this.node, server: this.instanceName});
   }
 
   @listen('restart.click')
   doRestart() {
-    console.log(`restart: server='${this.name}', node='${this.node}'`);
+    console.info(`Restart: server='${this.name}', node='${this.node}'`);
     this.api.restartServer({node: this.node, server: this.instanceName});
   }
 
@@ -184,7 +184,6 @@ export class LabradNodes extends polymer.Base {
 
   @observe('api')
   apiChanged(newApi: NodeApi, oldApi: NodeApi) {
-    console.log('apiChanged', newApi, oldApi);
     if (this.defined(newApi)) {
       newApi.nodeStatus.add((msg) => this.onNodeStatus(msg), this.lifetime);
       newApi.serverStatus.add((msg) => this.onServerStatus(msg), this.lifetime);
@@ -193,7 +192,6 @@ export class LabradNodes extends polymer.Base {
 
   @observe('managerApi')
   managerChanged(newManager: ManagerApi, oldManager: ManagerApi) {
-    console.log('managerChanged', newManager, oldManager);
     if (this.defined(newManager)) {
       newManager.serverDisconnected.add((msg) => this.onServerDisconnected(msg), this.lifetime);
     }
@@ -202,7 +200,6 @@ export class LabradNodes extends polymer.Base {
   // callbacks invoked when we receive remote messages
 
   onNodeStatus(msg: NodeStatus): void {
-    console.log('onNodeStatus', msg);
     // we need to splice this new NodeStatus into the current info array.
     // first, check to see whether we already have status for this node.
     var idx = this._nodeIndex(msg.name);
@@ -216,7 +213,7 @@ export class LabradNodes extends polymer.Base {
   }
 
   onServerDisconnected(msg: ServerDisconnectMessage): void {
-    console.log('server disconnected:', msg.name);
+    console.warn('Server disconnected:', msg.name);
     var idx = this._nodeIndex(msg.name);
 
     if (idx >= 0) {
@@ -226,7 +223,6 @@ export class LabradNodes extends polymer.Base {
   }
 
   onServerStatus(msg: ServerStatusMessage): void {
-    console.log('onServerStatus', msg);
     var instances = Polymer.dom(this.root).querySelectorAll('labrad-instance-controller');
     for (var i = 0; i < instances.length; i++) {
       var instance = <any>instances[i];

--- a/client-js/app/elements/labrad-plot.ts
+++ b/client-js/app/elements/labrad-plot.ts
@@ -623,13 +623,12 @@ export class Plot extends polymer.Base {
         selected.push(parseInt((<any>radio).selected)); 
         break;
     }
-    console.log("selected Traces: ", selected);
+
     if (selected.length > 0) {
       this.displayTraces.splice(0, this.displayTraces.length);
       for (let ent of selected) {
         this.displayTraces.push(ent);
       }
-      console.log("this.displayTraces: ", this.displayTraces);
       this.displaySurface = this.displayTraces[0] + 2;
       this.$.traceSelector.close();
       this.userTraces = true;

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -137,8 +137,8 @@ export class LabradRegistry extends polymer.Base {
   }
 
   handleError(error) {
-    //we can add a more creative way of displaying errors here
-    console.log(error);
+    // We can add a more creative way of displaying errors here.
+    console.error(error);
   }
 
 
@@ -203,7 +203,6 @@ export class LabradRegistry extends polymer.Base {
 
   @listen('dragend')
   endDrag(event) {
-    console.log('drag ended',event);
   }
 
   /**

--- a/client-js/app/scripts/activities.ts
+++ b/client-js/app/scripts/activities.ts
@@ -25,7 +25,7 @@ export class RegistryActivity implements Activity {
 
   async start(): Promise<ActivityState> {
     this.api.newItem.add(() => this.onNewItem(), this.lifetime);
-    console.log('loading registry:', this.path);
+    console.info('Loading registry:', this.path);
     await this.api.watch({path: this.path});
     var listing = await this.api.dir({path: this.path});
     var breadcrumbs = [];
@@ -73,7 +73,7 @@ export class DatavaultActivity implements Activity {
               public path: Array<string>) {}
 
   async start(): Promise<ActivityState> {
-    console.log('loading datavault:', this.path);
+    console.info('Loading datavault:', this.path);
     this.api.newDir.add(x => this.onNewDir(), this.lifetime);
     this.api.newDataset.add(x => this.onNewDataset(), this.lifetime);
     this.api.tagsUpdated.add(x => this.tagsUpdated(), this.lifetime);
@@ -259,7 +259,7 @@ export class DatasetActivity implements Activity {
   }
 
   async start(): Promise<ActivityState> {
-    console.log('loading dataset:', this.path, this.dataset);
+    console.info('Loading dataset:', this.path, this.dataset);
     this.api.dataAvailable.add(msg => {
       if (msg.token === this.token) this.dataAvailable.offer(null);
     }, this.lifetime);

--- a/client-js/app/scripts/app.ts
+++ b/client-js/app/scripts/app.ts
@@ -109,7 +109,6 @@ window.addEventListener('WebComponentsReady', () => {
     // Strip trailing slash, since routes have leading slash already.
     prefix = href.substring(0, href.length - 1);
   }
-  console.log('urlPrefix', prefix);
 
   var body = document.querySelector('body');
   body.removeAttribute('unresolved');
@@ -181,7 +180,7 @@ window.addEventListener('WebComponentsReady', () => {
       content.appendChild(state.elem);
       activity = newActivity;
     } catch (error) {
-      console.log('error while starting activity', error);
+      console.error('Error while starting activity', error);
     }
   }
 
@@ -363,11 +362,11 @@ window.addEventListener('WebComponentsReady', () => {
         await promises.sleep(5000);
         var services: Services = null;
         try {
-          console.log('attempting to connect');
+          console.log('Attempting to connect');
           services = await login(host, false);
           break;
         } catch (e) {
-          console.log('connection failed', e);
+          console.error('Connection failed', e);
           if (isPasswordError(e)) {
             break;
           }

--- a/client-js/app/scripts/app.ts
+++ b/client-js/app/scripts/app.ts
@@ -362,7 +362,7 @@ window.addEventListener('WebComponentsReady', () => {
         await promises.sleep(5000);
         var services: Services = null;
         try {
-          console.log('Attempting to connect');
+          console.info('Attempting to connect');
           services = await login(host, false);
           break;
         } catch (e) {

--- a/client-js/app/scripts/rpc.ts
+++ b/client-js/app/scripts/rpc.ts
@@ -75,11 +75,8 @@ export class JsonRpcSocket {
         }
       } else if (json.hasOwnProperty("id")) {
         // call
-        console.log('call', json);
         this.callMethod(json);
       } else {
-        // notification
-        console.log('notification', json);
         var method = json["method"];
         if (this.notifiables.hasOwnProperty(method)) {
           this.notifiables[method](json["params"]);


### PR DESCRIPTION
Writting to the console harms performance, and excessive logging makes it very
difficult to follow. Removed all calls to console.log or promoted them to a
more appropriate console logging type: warn, info or error. Console log should
be disabled before merging with master. Chrome Development tools have a lot of
tools, such as to inspect websocket traffic that should make console logging in
production (especially inside loops) unnecessary.
