### PR TITLE
Registry UI fixes

### DIFF
--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -141,7 +141,9 @@
       <table>
         <tbody is="selectable-table" id="combinedList" selected="{{selectedIdx}}">
           <template id="fullList" is="dom-repeat" items="{{listItems}}" filter="filterFunc">
-            <tr name="{{item.name}}">
+            <tr name="{{item.name}}"
+                key-name="{{item.name}}"
+                on-dblclick="editValueClicked">
               <template is="dom-if" if="{{item.isParent}}">
                 <td class="label-wide" colspan="2">
                   <iron-icon icon="arrow-back" item-icon></iron-icon>
@@ -163,17 +165,12 @@
               <template is="dom-if" if="{{item.isKey}}">
                 <td class="key mono"
                     name="{{item.name}}"
-                    key-name="{{item.name}}"
-                    on-dblclick="editValueClicked"
                     draggable="true">
-                  <iron-icon icon="communication:vpn-key" item-icon class="key"
-                             key-name="{{item.name}}" on-dblclick="editValueClicked"></iron-icon>
-                  <span key-name="{{item.name}}" on-dblclick="editValueClicked">{{item.name}}</span>
+                  <iron-icon icon="communication:vpn-key" item-icon class="key"></iron-icon>
+                  <span>{{item.name}}</span>
                 </td>
-                <td class="value label-wide mono"
-                    key-name="{{item.name}}"
-                    on-dblclick="editValueClicked">
-                  <span key-name="{{item.name}}" on-dblclick="editValueClicked">{{item.value}}</span>
+                <td class="value label-wide mono">
+                  <span>{{item.value}}</span>
                 </td>
               </template>
             </tr>

--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -131,6 +131,10 @@
     iron-icon.key {
       color: #209131;
     }
+    paper-dialog {
+      max-width: 90%;
+      max-height: 90%;
+    }
   </style>
   <template>
     <div id="reg-area">

--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -143,6 +143,7 @@
           <template id="fullList" is="dom-repeat" items="{{listItems}}" filter="filterFunc">
             <tr name="{{item.name}}"
                 key-name="{{item.name}}"
+                is-key="{{item.isKey}}"
                 on-dblclick="editValueClicked">
               <template is="dom-if" if="{{item.isParent}}">
                 <td class="label-wide" colspan="2">

--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -105,13 +105,22 @@
     }
     .mono {
       font-family: 'roboto mono', monospace;
+      font-size: 15px;
     }
     td.dir {
       white-space: nowrap;
       -webkit-user-select: none;  
     }
-    td.key-item {
+    td.key {
       white-space: nowrap;
+      padding-right: 2em;
+    }
+    td.value {
+      max-width: 100px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      padding-right: 1em;
     }
     iron-icon {
       margin: 5px;
@@ -130,14 +139,14 @@
           <template id="fullList" is="dom-repeat" items="{{listItems}}" filter="filterFunc">
             <tr name="{{item.name}}">
               <template is="dom-if" if="{{item.isParent}}">
-                <td>
+                <td class="label-wide" colspan="2">
                   <iron-icon icon="arrow-back" item-icon></iron-icon>
                   <a is="app-link" path="{{item.url}}" href="{{item.url}}">{{item.name}}</a>
                 </td>
-                <td class="label-wide"></td>
               </template>
               <template is="dom-if" if="{{item.isDir}}">
-                <td class="dir"
+                <td class="dir label-wide"
+                    colspan="2"
                     name="{{item.name}}"
                     draggable="true"
                     on-dragover="onDirDragOver"
@@ -146,19 +155,21 @@
                   <iron-icon icon="folder" item-icon class="folder"></iron-icon>
                   <a is="app-link" path="{{item.url}}" href="{{item.url}}">{{item.name}}</a>
                 </td>
-                <td class="label-wide"></td>
               </template>
               <template is="dom-if" if="{{item.isKey}}">
-                <td class="key"
+                <td class="key mono"
                     name="{{item.name}}"
+                    key-name="{{item.name}}"
+                    on-dblclick="editValueClicked"
                     draggable="true">
-                  <iron-icon icon="communication:vpn-key" item-icon class="key"></iron-icon>
-                  <span class="mono">{{item.name}}</span>
+                  <iron-icon icon="communication:vpn-key" item-icon class="key"
+                             key-name="{{item.name}}" on-dblclick="editValueClicked"></iron-icon>
+                  <span key-name="{{item.name}}" on-dblclick="editValueClicked">{{item.name}}</span>
                 </td>
-                <td class="label-wide">
-                  <paper-item key-name="{{item.name}}" on-dblclick="editValueClicked">
-                    <span class="mono">{{item.value}}</span>
-                  </paper-item>
+                <td class="value label-wide mono"
+                    key-name="{{item.name}}"
+                    on-dblclick="editValueClicked">
+                  <span key-name="{{item.name}}" on-dblclick="editValueClicked">{{item.value}}</span>
                 </td>
               </template>
             </tr>

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -299,7 +299,7 @@ export class LabradRegistry extends polymer.Base {
   editValueClicked(event) {
     var dialog = this.$.editValueDialog,
         editValueElem = this.$.editValueInput,
-        name = event.target.keyName,
+        name = event.currentTarget.keyName,
         value: string = null,
         found = false;
     for (let item of this.keys) {

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -300,8 +300,10 @@ export class LabradRegistry extends polymer.Base {
     var dialog = this.$.editValueDialog,
         editValueElem = this.$.editValueInput,
         name = event.currentTarget.keyName,
+        isKey = event.currentTarget.isKey,
         value: string = null,
         found = false;
+    if (!isKey) return;
     for (let item of this.keys) {
       if (item.name == name) {
         value = item.value;


### PR DESCRIPTION
- Limit registry keys to a single line in the main list view with ellipsis when a key is truncated.
- Allow double clicking anywhere on a registry key to edit, including the icon and text.
- Improve polymer dialog style when resizing page so edit box does not go off screen.

@DanielSank, @adamcw
