### PR TITLE
Modified gulp to allow a --host flag to determine websocket host.

### DIFF
--- a/client-js/gulpfile.js
+++ b/client-js/gulpfile.js
@@ -25,8 +25,10 @@ var gitDescribe = require('git-describe');
 var minimist = require('minimist');
 
 var knownOptions = {
-  string: 'host',
-  default: { host: 'localhost:7667' }
+  string: 'api-host',
+  default: { 
+    'api-host': 'localhost:7667'
+  }
 };
 
 var options = minimist(process.argv.slice(2), knownOptions);
@@ -254,7 +256,7 @@ gulp.task('insert-dev-config', function () {
   return gulp.src(['app/index.html'])
     .pipe($.replace('<!-- DEV_MODE_CONFIG -->', [
                       '<!-- DEV_MODE_CONFIG -->',
-                      metaTag("labrad-apiHost", "ws://" + options.host),
+                      metaTag("labrad-apiHost", "ws://" + options['api-host']),
                       metaTag("labrad-clientVersion", gitVersion())
                     ].join("\n    ")))
     .pipe(gulp.dest('.tmp'));

--- a/client-js/gulpfile.js
+++ b/client-js/gulpfile.js
@@ -22,6 +22,15 @@ var jasmineBrowser = require('gulp-jasmine-browser');
 var jasmine = require('gulp-jasmine');
 var gitDescribe = require('git-describe');
 
+var minimist = require('minimist');
+
+var knownOptions = {
+  string: 'host',
+  default: { host: 'localhost:7667' }
+};
+
+var options = minimist(process.argv.slice(2), knownOptions);
+
 var AUTOPREFIXER_BROWSERS = [
   'ie >= 10',
   'ie_mob >= 10',
@@ -245,7 +254,7 @@ gulp.task('insert-dev-config', function () {
   return gulp.src(['app/index.html'])
     .pipe($.replace('<!-- DEV_MODE_CONFIG -->', [
                       '<!-- DEV_MODE_CONFIG -->',
-                      metaTag("labrad-apiHost", "ws://localhost:7667"),
+                      metaTag("labrad-apiHost", "ws://" + options.host),
                       metaTag("labrad-clientVersion", gitVersion())
                     ].join("\n    ")))
     .pipe(gulp.dest('.tmp'));

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -40,6 +40,7 @@
     "jspm": "^0.15.7",
     "merge-stream": "^0.1.7",
     "merge2": "^0.3.6",
+    "minimist": "^1.2.0",
     "opn": "^1.0.0",
     "require-dir": "^0.3.0",
     "run-sequence": "^1.0.2",


### PR DESCRIPTION
Previously the websocket gulp inserted into the web client was hardcoded to be
localhost:7667. This change allows any host to be provided via the --host
command line flag, eg `gulp serve --host adamcw.example.com:7667`.
