### PR TITLE
Updated Polymer to v1.5.X in bower.json

### DIFF
--- a/client-js/bower.json
+++ b/client-js/bower.json
@@ -6,7 +6,7 @@
     "iron-elements": "PolymerElements/iron-elements#1.x",
     "neon-elements": "PolymerElements/neon-elements#1.x",
     "paper-elements": "PolymerElements/paper-elements#1.x",
-    "polymer": "Polymer/polymer#1.4.x",
+    "polymer": "Polymer/polymer#1.5.x",
     "polymer-ts": "nippur72/PolymerTS#0.1.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Due to package element dependencies requiring Polymer 1.5.0, we need to resolve
the conflict between required versions. It is preferred to update to the latest
version of Polymer, rather than freeze it at an older version.
