### PR TITLE
Fixed cursor positioning on grapher.

### DIFF
--- a/client-js/app/elements/labrad-plot.ts
+++ b/client-js/app/elements/labrad-plot.ts
@@ -249,14 +249,16 @@ export class Plot extends polymer.Base {
 
   @listen('plot.mousemove')
   mouseMove(event) {
+    const rect = event.currentTarget.getBoundingClientRect();
     var xMin = this.xScale.invert(0),
         xMax = this.xScale.invert(this.width),
         yMin = this.yScale.invert(this.height),
         yMax = this.yScale.invert(0),
         dx = (xMax - xMin) / this.width,
         dy = (yMax - yMin) / this.height,
-        x = this.mouseToDataX(event.offsetX),
-        y = this.mouseToDataY(event.offsetY);
+        x = this.mouseToDataX(event.pageX - rect.left),
+        y = this.mouseToDataY(event.pageY - rect.top);
+
     this.currPos = `(${prettyNumber(x, xMin, xMax, dx)}, ${prettyNumber(y, yMin, yMax, dy)})`;
   }
 


### PR DESCRIPTION
Cursor positioning was messed up in two ways. Firstly, it wasn't correctly
accounting for the offset of the graph from the side and top of the page.
Secondly, the use of `offsetX` was relative to the item that you moused over
rather than the graph, so mousing directly over a line would cause the
positioning to jump to non-sense values as the offsets were incorrect for the
intended purpose. Fixed by using currentTarget and getBoundingClientRect to
manually calculate the offset relative to the plot.
