### PR TITLE
Created an IronIconBakery and ListBuilder class to allow for more performant UI.

### DIFF
--- a/client-js/app/elements/labrad-grapher.html
+++ b/client-js/app/elements/labrad-grapher.html
@@ -104,7 +104,7 @@
           <div id="listing">
             <table>
               <tbody id='selectable-table' is="selectable-table" selected="{{selectedId}}" attr-for-selected="selid">
-                
+                <!-- List is generated from within labrad-grapher.ts for performance reasons -->
               </tbody>
             </table>
           </div>

--- a/client-js/app/elements/labrad-grapher.html
+++ b/client-js/app/elements/labrad-grapher.html
@@ -41,19 +41,19 @@
     #buttons paper-icon-button {
       margin: 5px;
     }
-    #listing iron-icon {
+    #listing .iron-icon {
       margin: 5px;
     }
-    #listing iron-icon.folder {
+    #listing .iron-icon.folder {
       color: #CFBA78;
     }
-    #listing iron-icon.dataset {
+    #listing .iron-icon.dataset {
       color: #209131;
     }
-    #listing iron-icon.star {
+    #listing .iron-icon.star {
       color: #FF2299;
     }
-    #listing iron-icon.trash {
+    #listing .iron-icon.trash {
       color: #773300;
     }
     #right-column {
@@ -103,31 +103,8 @@
           </div>
           <div id="listing">
             <table>
-              <tbody is="selectable-table" selected="{{selectedId}}" attr-for-selected="selid">
-                <template is="dom-repeat" items="{{listItems}}">
-                  <tr selid="{{item.id}}">
-                    <td class="item">
-                      <template is="dom-if" if="{{item.isParent}}">
-                        <iron-icon icon="arrow-back" item-icon></iron-icon>
-                      </template>
-                      <template is="dom-if" if="{{item.isDir}}">
-                        <iron-icon icon="folder" item-icon class="folder"></iron-icon>
-                      </template>
-                      <template is="dom-if" if="{{item.isDataset}}">
-                        <iron-icon icon="editor:insert-chart" item-icon class="dataset"></iron-icon>
-                      </template>
-                      <a is="app-link" path="{{item.url}}" href="{{item.url}}">{{item.name}}</a>
-                    </td>
-                    <td class="label-wide">
-                      <template is="dom-if" if="{{item.starred}}">
-                        <iron-icon icon="stars" class="star"></iron-icon>
-                      </template>
-                      <template is="dom-if" if="{{item.trashed}}">
-                        <iron-icon icon="delete" class="trash"></iron-icon>
-                      </template>
-                    </td>
-                  </tr>
-                </template>
+              <tbody id='selectable-table' is="selectable-table" selected="{{selectedId}}" attr-for-selected="selid">
+                
               </tbody>
             </table>
           </div>

--- a/client-js/app/elements/labrad-grapher.ts
+++ b/client-js/app/elements/labrad-grapher.ts
@@ -44,11 +44,15 @@ export class LabradGrapher extends polymer.Base {
 
   updateList() {
     const element = Polymer.dom(document.getElementById('selectable-table'));
-    while (element.firstElementChild) {
-      element.removeChild(element.firstElementChild);
-    }
-    const items = this.listItems(this.path, this.dirs, this.datasets, this.kick);
-    this.listBuilder.render(items, element, (item) => this.listItem(item));
+    requestAnimationFrame(() => {
+      while (element.firstElementChild) {
+        element.removeChild(element.firstElementChild);
+      }
+    });
+    const items = this.listItems(
+        this.path, this.dirs, this.datasets, this.kick);
+    this.listBuilder.render(
+        items, element, (item) => this.listItem(item), 50, 250);
   }
 
   starClicked() {
@@ -74,12 +78,10 @@ export class LabradGrapher extends polymer.Base {
 
   listItem(item: Object) : HTMLElement {
     const tr = document.createElement('tr');
-
-    tr.className = 'style-scope labrad-grapher ';
     tr.setAttribute('selid', item.id);
 
     const td1 = document.createElement('td');
-    td1.className = 'style-scope labrad-grapher ' + 'item';
+    td1.className = 'item';
 
     if (item.isParent) {
       td1.appendChild(this.iconBakery.get('arrow-back'));
@@ -100,7 +102,7 @@ export class LabradGrapher extends polymer.Base {
     td1.appendChild(aItem);
 
     const td2 = document.createElement('td');
-    td2.className = 'style-scope labrad-grapher ' + 'label-wide';
+    td2.className = 'label-wide';
 
     if (item.starred) {
       td2.appendChild(this.iconBakery.get('stars'));

--- a/client-js/app/scripts/ironiconbakery.ts
+++ b/client-js/app/scripts/ironiconbakery.ts
@@ -1,0 +1,72 @@
+/**
+ * Allows efficient generation of SVG icon nodes.
+ *
+ * The base iron-icon functionality provides numerous event listeners and data
+ * binding properties that make them tremendously slow if you just want them
+ * for their artistic merits. Generates SVG and container DOM nodes and caches
+ * them so that repeated calls are performant.
+ */
+export class IronIconBakery {
+  private styleNamespace_ = '';
+  private icons_: Object = {};
+
+
+
+  /**
+   * Create a new IronIconBakery for a given namespace. This will be the name
+   * of the component making use of the bakery. It will append this name as a
+   * class to the icon so that appropriate style-scoping by Polymer continues.
+   */
+  constructor(styleNamespace: string) {
+    this.styleNamespace_ = styleNamespace;
+  }
+
+
+  /**
+   * Generates and caches the DOM elements required to render an icon-icon
+   * efficiently.
+   */
+  public get(name: string, className?: string) {
+    if (this.icons_.hasOwnProperty(name)) {
+      return this.icons_[name].cloneNode(true);
+    }
+
+    const container = document.createElement('div');
+    container.className = this.styleNamespace_ + ' style-scope iron-icon iron-icon-0 ' + (className || name);
+
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    svg.setAttribute('viewBox', '0 0 24 24');
+    svg.setAttribute('style', 'width: 24px; height: 24px;');
+
+    const group = document.createElementNS("http://www.w3.org/2000/svg", 'g');
+    const path = document.createElementNS("http://www.w3.org/2000/svg", 'path');
+    path.setAttribute('d', this.paths_(name));
+    group.appendChild(path);
+    svg.appendChild(group);
+    container.appendChild(svg);
+
+    this.icons_[name] = container;
+    return container;
+  }
+
+
+  /**
+   * Returns the SVG path for a specific icon.
+   * Icons taken from iron-icons.
+   */
+  private paths_(name: string) {
+    switch (name) {
+      case 'stars':
+        return 'M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zm4.24 16L12 15.45 7.77 18l1.12-4.81-3.73-3.23 4.92-.42L12 5l1.92 4.53 4.92.42-3.73 3.23L16.23 18z';
+      case 'arrow-back':
+        return 'M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z';
+      case 'folder':
+        return 'M10 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2z';
+      case 'editor:insert-chart':
+        return 'M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z';
+      case 'trash':
+        return 'M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z';
+    }
+    return '';
+  }
+}

--- a/client-js/app/scripts/listbuilder.ts
+++ b/client-js/app/scripts/listbuilder.ts
@@ -1,0 +1,106 @@
+/**
+ * Allows for the generation of a large list of DOM nodes by chunking the
+ * rendering.
+ */
+export class ListBuilder {
+  /**
+   * Whether or not there is current a list rendering.
+   */
+  public isRendering: boolean = false;
+
+
+  /**
+   * The current renderId of a new render.
+   */
+  private renderId_: number = 0;
+
+
+  /**
+   * All chunks in the queue with a renderId less than or equal to this number
+   * will not fire, and will consider themselves interrupted.
+   */
+  private renderInterrupt_: number = -1;
+
+
+  /**
+   * The current chunks that are yet to be rendered.
+   */
+  private chunkQueue_: Array = [];
+
+
+  /**
+   * Renders a list of items, appending them to an element in chunks.
+   *
+   * Will chunk `listItems` into chunks of size `chunkSize` and then queue them
+   * to fire one chunk per animation frame. Each chunk will be evaluated by
+   * passing each element in `listItems` to `func` which should return a
+   * `HTMLElement`.
+   */
+  public render(listItems: Array, element: HTMLElement, func: Function, chunkSize?: number) {
+    chunkSize = chunkSize || 200;
+
+    // If we are currently rendering, interuppt all elements currently in the
+    // queue and increment the renderId.
+    if (this.isRendering) {
+      this.renderInterrupt_ = renderId;
+      this.renderId_++;
+    }
+
+    this.isRendering = true;
+
+    const list = listItems;
+    const length = list.length;
+    const numChunks = Math.ceil(length / chunkSize);
+
+    for (let chunkId = 0; chunkId < numChunks; ++chunkId) {
+      const chunkLength = (chunkId == numChunks - 1) ? list.length % chunkSize : chunkSize;
+
+      this.chunkQueue_.push({
+        renderId: this.renderId_,
+        func: () => {
+          const docFragment = document.createDocumentFragment();
+
+          const index = chunkSize * chunkId;
+          for (let i = 0; i < chunkLength; ++i) {
+            const item = list[index + i];
+            docFragment.appendChild(func(item));
+          }
+
+          element.appendChild(docFragment);
+        }
+      });
+    }
+
+    // Render the first chunk immediately
+    this.dequeueChunk_();
+    this.emptyChunkQueue_();
+  }
+
+
+  /**
+   * Takes the chunk from the head of the list and renders it if it has not
+   * been interrupted.
+   */
+  dequeueChunk_() {
+    const {renderId, func} = this.chunkQueue_.shift();
+    if (renderId > this.renderInterrupt_) {
+      func();
+    }
+  }
+
+
+  /**
+   * Continuously dequeues chunks until the queue is empty.
+   */
+  emptyChunkQueue_() {
+    if (this.chunkQueue_.length == 0) {
+      this.isRendering = false;
+      return;
+    }
+
+    requestAnimationFrame(() => {
+      this.dequeueChunk_();
+      this.emptyChunkQueue_();
+    });
+  }
+}


### PR DESCRIPTION
Applied these classes to the Grapher directory/dataset listing.

Polymer does a lot of fancy data-binding and event listening, which makes things
very slow at scale. Rendering a list of 4000 datasets would freeze the entire
application for 6-7 seconds, sometimes more. Even traversing simple lists took
a noticeable amount of time which just leads to a frustrating user experience,
especially if navigating multiple levels of a directory structure.

To fix this, I've moved the rendering of the grapher list view into raw
JavaScript rather than using the Polymer templating language. As a result,
small lists now render instantly, and large lists, while still take a few
seconds to entirely load (the DOM just doesn't like this many elements being
added) the page and the top of the list renders instantly giving the user the
impression of speed.

This implementation could be further optimized, but should already be overkill for the average use case, with filtering really the solution to lists greater than a few hundred items rather than trying to speed up huge DOM insertions.

This PR is a first step towards overhauling and unifying the list views across
the application to allow for easier fixes and improvements to the UI.
