### PR TITLE
Update the Registry menu UI styling

### DIFF
--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -67,6 +67,7 @@
 
     }
     .label-wide {
+      min-width: 500px;
       width: 100%;
     }
     paper-toolbar {
@@ -109,7 +110,7 @@
     }
     td.dir {
       white-space: nowrap;
-      -webkit-user-select: none;  
+      -webkit-user-select: none;
     }
     td.key {
       white-space: nowrap;
@@ -135,6 +136,20 @@
       max-width: 90%;
       max-height: 90%;
     }
+    .label-wide a {
+      text-decoration: none;
+    }
+    .label-wide a span {
+      text-decoration: underline;
+    }
+    .label-wide .back-link,
+    .label-wide .back-link:visited {
+      color: #555;
+    }
+    .label-wide .back-link:hover {
+    .label-wide .back-link:visited:hover {
+      color: #3f51b5;
+    }
   </style>
   <template>
     <div id="reg-area">
@@ -147,8 +162,10 @@
                 on-dblclick="editValueClicked">
               <template is="dom-if" if="{{item.isParent}}">
                 <td class="label-wide" colspan="2">
-                  <iron-icon icon="arrow-back" item-icon></iron-icon>
-                  <a is="app-link" path="{{item.url}}" href="{{item.url}}">{{item.name}}</a>
+                  <a class='back-link' is="app-link" path="{{item.url}}" href="{{item.url}}">
+                    <iron-icon icon="arrow-back" item-icon></iron-icon>
+                    <span>{{item.name}}</span>
+                  </a>
                 </td>
               </template>
               <template is="dom-if" if="{{item.isDir}}">
@@ -159,8 +176,10 @@
                     on-dragover="onDirDragOver"
                     on-dragleave="onDirDragLeave"
                     on-drop="dirDrop">
-                  <iron-icon icon="folder" item-icon class="folder"></iron-icon>
-                  <a is="app-link" path="{{item.url}}" href="{{item.url}}">{{item.name}}</a>
+                  <a is="app-link" path="{{item.url}}" href="{{item.url}"}>
+                    <iron-icon icon="folder" item-icon class="folder"></iron-icon>
+                    <span>{{item.name}}</span>
+                  </a>
                 </td>
               </template>
               <template is="dom-if" if="{{item.isKey}}">

--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -7,6 +7,7 @@
   <style>
     :host {
       display: block;
+      width: 100%;
     }
 
     #reg-menu {
@@ -22,6 +23,7 @@
       display: inline-block;
       @apply(--shadow-elevation-2dp);
       height: 100%;
+      width: 100%;
     }
 
     tbody tr:nth-child(1n).iron-selected {
@@ -67,7 +69,6 @@
 
     }
     .label-wide {
-      min-width: 500px;
       width: 100%;
     }
     paper-toolbar {

--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -147,7 +147,7 @@
     .label-wide .back-link:visited {
       color: #555;
     }
-    .label-wide .back-link:hover {
+    .label-wide .back-link:hover,
     .label-wide .back-link:visited:hover {
       color: #3f51b5;
     }
@@ -177,7 +177,7 @@
                     on-dragover="onDirDragOver"
                     on-dragleave="onDirDragLeave"
                     on-drop="dirDrop">
-                  <a is="app-link" path="{{item.url}}" href="{{item.url}"}>
+                  <a is="app-link" path="{{item.url}}" href="{{item.url}}">
                     <iron-icon icon="folder" item-icon class="folder"></iron-icon>
                     <span>{{item.name}}</span>
                   </a>


### PR DESCRIPTION
A few simple changes to the Register menu UI
- Items are now always the full width of the screen.
- The icons are now clickable.
- The back arrow is now always a black color instead of being link colored (you've generally visited the parent to get to the child, so the back link being 'visited' is meaningless).
