### PR TITLE
Update d3 to v3.5.17

### DIFF
--- a/client-js/config.js
+++ b/client-js/config.js
@@ -10,7 +10,7 @@ System.config({
 
 System.config({
   "map": {
-    "d3": "github:mbostock/d3@3.5.6",
+    "d3": "github:mbostock/d3@3.5.17",
     "page": "npm:page@1.6.3",
     "traceur": "github:jmcriffey/bower-traceur@0.0.88",
     "traceur-runtime": "github:jmcriffey/bower-traceur-runtime@0.0.88",

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -59,7 +59,7 @@
   "jspm": {
     "directories": {},
     "dependencies": {
-      "d3": "github:d3/d3@^3.5.6",
+      "d3": "github:d3/d3@^3.5.17",
       "page": "npm:page@^1.6.3"
     },
     "devDependencies": {


### PR DESCRIPTION
Updated to the latest d3 since it's preferred to be on the latest version if it doesn't break anything. v4.0.0 is going to bring a lot of changes, so we should probably try and keep up to date to avoid accidentally using old features where possible.
