### PR TITLE
Enabled cmd/ctrl click.

### DIFF
--- a/client-js/app/elements/app-link.html
+++ b/client-js/app/elements/app-link.html
@@ -1,6 +1,6 @@
 <script>
 (function () {
-  const MOUSE_LEFT_BUTTON = 0;
+  var MOUSE_MAIN_BUTTON = 0;
 
   Polymer({
     is: 'app-link',
@@ -13,7 +13,7 @@
     },
 
     isSpecialClick: function(e) {
-      return (e.ctrlKey || e.metaKey || e.button !== MOUSE_LEFT_BUTTON);
+      return (e.ctrlKey || e.metaKey || e.button !== MOUSE_MAIN_BUTTON);
     },
 
     onClick: function(e) {

--- a/client-js/app/elements/app-link.html
+++ b/client-js/app/elements/app-link.html
@@ -1,5 +1,7 @@
 <script>
 (function () {
+  const MOUSE_LEFT_BUTTON = 0;
+
   Polymer({
     is: 'app-link',
 
@@ -10,16 +12,21 @@
       'tap': 'onTap'
     },
 
+    isSpecialClick: function(e) {
+      return (e.ctrlKey || e.metaKey || e.button !== MOUSE_LEFT_BUTTON);
+    },
+
     onClick: function(e) {
-      if (e.ctrlKey || e.metaKey || e.button !== 0) {
-        return true;
-      }
+      if (this.isSpecialClick(e)) return;
+
       this.fire('app-link-click', {path: this.path});
       e.preventDefault();
       e.stopPropagation();
     },
 
     onTap: function(e) {
+      if (this.isSpecialClick(e)) return;
+
       e.preventDefault();
       e.stopPropagation();
     }


### PR DESCRIPTION
Fixed issue #164 where `cmd+click` and `ctrl+click` didn't have their default behavior of opening in a new tab.

Resolved by stopping the `tap` event from capturing the `click` event when `meta` or `ctrl` is held.
