### PR TITLE
Updated 1D plots to be easier to read.

### DIFF
--- a/client-js/app/elements/labrad-plot.ts
+++ b/client-js/app/elements/labrad-plot.ts
@@ -6,14 +6,20 @@ import * as datavault from "../scripts/datavault";
 
 /**
  * Colors for traces in 1D plots.
+ * Chosen to contrast well even for color blind invididuals.
+ * Reference: http://mkweb.bcgsc.ca/biovis2012.
+ * GitHub Discussion: issues/145.
  */
 const COLOR_LIST = [
-  '#0000ff',
-  '#ff0000',
-  '#00cc00',
-  '#dddd00',
-  '#dd00dd',
-  '#0088dd'
+  d3.rgb(36, 255, 36), // Green.
+  d3.rgb(0, 109, 219), // Blue.
+  d3.rgb(73, 0, 146), // Purple.
+  d3.rgb(219, 109, 0), // Orange.
+  d3.rgb(255, 182, 219), // Pale Pink.
+  d3.rgb(0, 0, 0), // Black.
+  d3.rgb(182, 219, 255), // Pale Blue.
+  d3.rgb(146, 0, 0), // Maroon.
+  d3.rgb(182, 109, 255), // Violet.
 ];
 
 

--- a/client-js/app/elements/labrad-plot.ts
+++ b/client-js/app/elements/labrad-plot.ts
@@ -6,20 +6,18 @@ import * as datavault from "../scripts/datavault";
 
 /**
  * Colors for traces in 1D plots.
- * Chosen to contrast well even for color blind invididuals.
- * Reference: http://mkweb.bcgsc.ca/biovis2012.
- * GitHub Discussion: issues/145.
  */
 const COLOR_LIST = [
-  d3.rgb(36, 255, 36), // Green.
-  d3.rgb(0, 109, 219), // Blue.
-  d3.rgb(73, 0, 146), // Purple.
-  d3.rgb(219, 109, 0), // Orange.
-  d3.rgb(255, 182, 219), // Pale Pink.
-  d3.rgb(0, 0, 0), // Black.
-  d3.rgb(182, 219, 255), // Pale Blue.
-  d3.rgb(146, 0, 0), // Maroon.
-  d3.rgb(182, 109, 255), // Violet.
+  "#3366cc", // Blue.
+  "#dc3912", // Red.
+  "#ff9900", // Orange.
+  "#109618", // Green.
+  "#990099", // Purple.
+  "#22aa99", // Teal.
+  "#dd4477", // Pink.
+  "#0099c6", // Aqua.
+  "#aaaa11", // Yellow.
+  "#000000", // Black.
 ];
 
 

--- a/client-js/app/elements/labrad-plot.ts
+++ b/client-js/app/elements/labrad-plot.ts
@@ -309,6 +309,7 @@ export class Plot extends polymer.Base {
         this.chartBody.append('svg:path')
                 .datum(traceData)
                 .attr('stroke', COLOR_LIST[i % COLOR_LIST.length])
+                .attr('stroke-width', 1.5)
                 .attr('fill', 'none')
                 .attr('class', `line${i}`)
                 .attr('d', this.line);


### PR DESCRIPTION
Fixes issue #145 by updating the 1D plots in grapher to use the same default colors as Google Charts as well as increasing the stroke width to 1.5 (up from 1.0).
