### PR TITLE
Fix issue where Grapher live view plots could overlap.

### DIFF
--- a/client-js/app/elements/labrad-grapher-live.html
+++ b/client-js/app/elements/labrad-grapher-live.html
@@ -5,12 +5,8 @@
     <style>
       :host {
         display: block;
-        height: 100%;
       }
       #plots {
-        display: flex;
-        flex-direction: column;
-        height: 100%;
       }
     </style>
     <div id="plots"></div>
@@ -21,12 +17,9 @@
   <template>
     <style>
       :host {
-        width: 100%;
-        display: flex;
-        flex-direction: column;
+        min-height: 450px;
       }
       #plot {
-        height: 400px;
         display: flex;
       }
     </style>

--- a/client-js/app/elements/labrad-grapher-live.html
+++ b/client-js/app/elements/labrad-grapher-live.html
@@ -5,8 +5,12 @@
     <style>
       :host {
         display: block;
+        height: 100%;
       }
       #plots {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
       }
     </style>
     <div id="plots"></div>
@@ -17,10 +21,15 @@
   <template>
     <style>
       :host {
+        width: 100%;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
         min-height: 450px;
       }
       #plot {
-        display: flex;
+        min-height: 400px;
+        height: 100%;
       }
     </style>
     <a is="app-link" path="{{url}}" href="{{url}}">{{name}}</a>

--- a/client-js/app/elements/labrad-plot.ts
+++ b/client-js/app/elements/labrad-plot.ts
@@ -111,8 +111,8 @@ export class Plot extends polymer.Base {
    * Fires when the component is attached to the DOM.
    */
   public attached() {
-    this.redraw_();
-    window.addEventListener('resize', (event) => this.redraw_());
+    this.redraw();
+    window.addEventListener('resize', (event) => this.redraw());
   }
 
 
@@ -473,7 +473,10 @@ export class Plot extends polymer.Base {
   }
 
 
-  private redraw_() {
+  /**
+   * Destroys and recreates the plot.
+   */
+  redraw(): void {
     const area = this.$.plot,
         rect = area.getBoundingClientRect();
     while (area.firstChild) {
@@ -740,7 +743,7 @@ export class Plot extends polymer.Base {
       this.displaySurface = this.displayTraces[0] + 2;
       this.$.traceSelector.close();
       this.userTraces = true;
-      this.redraw_();
+      this.redraw();
     }
   }
 

--- a/client-js/app/scripts/activities.ts
+++ b/client-js/app/scripts/activities.ts
@@ -232,7 +232,7 @@ export class DatavaultLiveActivity implements Activity {
     // resize all plots to ensure they fit the view.
     if (this.activities.length <= 3) {
       for (const activity of this.activities) {
-        activity.plot.redraw_();
+        activity.plot.redraw();
       }
     }
 
@@ -264,7 +264,7 @@ export class DatasetActivity implements Activity {
   private dataAvailable = new AsyncQueue<void>();
   private token = String(Math.random());
 
-  private plot: Plot;
+  plot: Plot;
 
   constructor(private places: Places,
               private api: datavault.DataVaultApi,

--- a/client-js/app/scripts/activities.ts
+++ b/client-js/app/scripts/activities.ts
@@ -227,6 +227,15 @@ export class DatavaultLiveActivity implements Activity {
     labeled.$.plot.appendChild(plot);
     this.elem.addPlot(labeled);
     this.activities.push(activity);
+
+    // If there were fewer than three activities before adding the new one,
+    // resize all plots to ensure they fit the view.
+    if (this.activities.length <= 3) {
+      for (const activity of this.activities) {
+        activity.plot.redraw_();
+      }
+    }
+
     while (this.activities.length > 3) {
       var activity = this.activities.shift();
       activity.stop();


### PR DESCRIPTION
Fix for issue #154 where the plots on the Grapher live view could overlap if the page was less than the `450*num_plot` as each plot and its label require a minimum height to display.

The original implementation of `flex` would make each plot consistently 33% of the page when there were three plots, inconsiderate of minimum plot height.

This fix implements a minimum height, as well as applies the redraw function when plots are added so that plots are appropriately resized when new plots are added.
