### PR TITLE
Add a small footer to the UI so that important information isn't obscured by browser status bars.

### DIFF
--- a/client-js/app/elements/labrad-app.html
+++ b/client-js/app/elements/labrad-app.html
@@ -1,6 +1,14 @@
 <link rel="import" href="../bower_components/paper-checkbox/paper-checkbox.html">
 
 <dom-module id="labrad-app">
+  <style is="custom-style">
+  paper-header-panel {
+    --paper-header-panel-standard-container: {
+      display: flex;
+      flex-direction: column;
+    };
+  }
+  </style>
   <style>
     paper-menu iron-icon {
       margin-right: 33px;
@@ -48,9 +56,7 @@
     }
 
     #content {
-      position: absolute;
-      width: 100%;
-      height: 100%;
+      flex: 1;
     }
 
     #location {
@@ -69,6 +75,11 @@
     #tech-info p {
       font-size: 12px;
       font-family: monospace;
+    }
+
+    #footer {
+      height: 25px;
+      background-color: var(--paper-indigo-500);
     }
 
   </style>
@@ -135,6 +146,8 @@
 
         <!-- Main Content -->
         <div id="content"></div>
+
+        <div id="footer"></div>
 
       </paper-header-panel>
     </paper-drawer-panel>

--- a/client-js/app/elements/labrad-app.html
+++ b/client-js/app/elements/labrad-app.html
@@ -80,8 +80,8 @@
     #footer {
       height: 25px;
       background-color: var(--paper-indigo-500);
+      flex-shrink: 0;
     }
-
   </style>
   <template>
     <paper-drawer-panel id="drawerPanel" force-narrow disable-edge-swipe>

--- a/client-js/app/elements/labrad-grapher-live.html
+++ b/client-js/app/elements/labrad-grapher-live.html
@@ -10,7 +10,7 @@
       #plots {
         display: flex;
         flex-direction: column;
-        height: 100%;
+        flex: 1;
       }
     </style>
     <div id="plots"></div>
@@ -24,12 +24,15 @@
         width: 100%;
         height: 100%;
         display: flex;
+        flex: 1;
         flex-direction: column;
         min-height: 450px;
       }
       #plot {
         min-height: 400px;
         height: 100%;
+        display: flex;
+        flex: 1;
       }
     </style>
     <a is="app-link" path="{{url}}" href="{{url}}">{{name}}</a>

--- a/client-js/app/elements/labrad-grapher.html
+++ b/client-js/app/elements/labrad-grapher.html
@@ -3,8 +3,9 @@
 <dom-module id="labrad-grapher">
   <style>
     :host {
-      display: block;
+      height: 100%;
       overflow: hidden;
+      display: flex;
     }
     table {
       width: 100%;
@@ -19,9 +20,7 @@
       white-space: nowrap;
     }
     #outer {
-      position: absolute;
-      width: 100%;
-      height: 100%;
+      flex: 1;
     }
     #container {
       display: flex;

--- a/client-js/app/elements/labrad-plot.html
+++ b/client-js/app/elements/labrad-plot.html
@@ -11,8 +11,10 @@
       position: relative;
     }
     #plot {
+      display: flex;
       flex-grow: 1;
       width: 400px;
+      min-height: 400px;
     }
     #pos {
       position: absolute;

--- a/client-js/app/elements/labrad-plot.ts
+++ b/client-js/app/elements/labrad-plot.ts
@@ -177,12 +177,13 @@ export class Plot extends polymer.Base {
             .on('zoom', () => this.handleZoom_());
 
     // Plot area.
+    const marginLeft = p.margin.left;
+    const marginTop = p.margin.top;
     p.svg = d3.select(area)
-            .append('svg:svg')
-            .attr('width', width + p.margin.left + p.margin.right)
-            .attr('height', height + p. margin.top + p.margin.bottom)
-            .append('g')
-            .attr('transform', `translate(${p.margin.left}, ${p.margin.top})`);
+              .append('svg:svg')
+                .attr('class', 'flex')
+                .append('g')
+                  .attr('transform', `translate(${marginLeft}, ${marginTop})`);
 
     // Background rectangle.
     p.svg.append('rect')
@@ -486,7 +487,7 @@ export class Plot extends polymer.Base {
    */
   redraw(): void {
     const area = this.$.plot,
-        rect = area.getBoundingClientRect();
+          rect = area.getBoundingClientRect();
     while (area.firstChild) {
       area.removeChild(area.firstChild);
     }


### PR DESCRIPTION
Fixes issue #147 by adding a small 25px footer to all pages so that any scrollable element cannot be obscured by the status bar that appears when hovering over links in browsers such as Google Chrome.

This change also begins to reduce the reliance on absolute positioning, moving towards a more consistent flex-based approach to positioning.
