### PR TITLE
Display error dialog on Grapher when Data Vault is unavailable.

### DIFF
--- a/client-js/app/elements/labrad-grapher.html
+++ b/client-js/app/elements/labrad-grapher.html
@@ -197,5 +197,14 @@
         </paper-header-panel>
       </div>
     </div>
+    <paper-dialog id="errorDialog" modal>
+      <h1>Unable to connect to Data Vault</h1>
+      <div>
+        <span>{{connectionError}}</span>
+      </div>
+      <div class="buttons">
+        <paper-button dialog-dismiss>Close</paper-button>
+      </div>
+    </paper-dialog>
   </template>
 </dom-module>

--- a/client-js/app/elements/labrad-grapher.ts
+++ b/client-js/app/elements/labrad-grapher.ts
@@ -85,6 +85,11 @@ export class LabradGrapher extends polymer.Base {
     return (selected) ? "iron-selected" : "";
   }
 
+  openUnableToConnectDialog(connectionError: string): void {
+    this.connectionError = connectionError;
+    this.$.errorDialog.open();
+  }
+
   @listen("keypress")
   onKeyPress(event): void {
     if (!this.selected) return;

--- a/client-js/app/scripts/activities.ts
+++ b/client-js/app/scripts/activities.ts
@@ -77,7 +77,7 @@ export class DatavaultActivity implements Activity {
     this.api.newDir.add(x => this.onNewDir(x), this.lifetime);
     this.api.newDataset.add(x => this.onNewDataset(x), this.lifetime);
     this.api.tagsUpdated.add(x => this.tagsUpdated(), this.lifetime);
-    var listing = await this.api.dir(this.path);
+
     var breadcrumbs = [];
     for (var i = 0; i <= this.path.length; i++) {
       breadcrumbs.push({
@@ -86,6 +86,7 @@ export class DatavaultActivity implements Activity {
         url: this.places.grapherUrl(this.path.slice(0, i))
       });
     }
+
     var breadcrumbExtras = [
       { name: 'dir view',
         isLink: false,
@@ -101,8 +102,16 @@ export class DatavaultActivity implements Activity {
     this.elem.api = this.api;
     this.elem.places = this.places;
     this.elem.path = this.path;
-    this.elem.dirs = this.getDirs(listing);
-    this.elem.datasets = this.getDatasets(listing);
+
+    try {
+      var listing = await this.api.dir(this.path);
+      this.elem.dirs = this.getDirs(listing);
+      this.elem.datasets = this.getDatasets(listing);
+    } catch (e) {
+      this.elem.openUnableToConnectDialog(e.message);
+      this.elem.dirs = [];
+      this.elem.datasets = [];
+    }
 
     return {
       elem: this.elem,


### PR DESCRIPTION
Fixes issue #187 where the Grapher just silently failed when the Data Vault was unavailable (except for a console error). 

Added a dialog box that displays the response from the Labrad server, as well made it so that the Grapher UI still renders somewhat nicely respite there being no data available.
