### PR TITLE
Add a color bar axis to the Grapher for 2D plots.

### DIFF
--- a/client-js/app/elements/labrad-plot.ts
+++ b/client-js/app/elements/labrad-plot.ts
@@ -26,6 +26,18 @@ const COLOR_MAP = viridisData.map((rgb) => {
 });
 
 
+const COLOR_BAR_WIDTH = 15;
+const COLOR_BAR_LEFT_MARGIN = 15;
+const COLOR_BAR_RIGHT_MARGIN = 5;
+const COLOR_BAR_AXIS_WIDTH = 40;
+const COLOR_BAR_STROKE_WIDTH = 0.75;
+const COLOR_BAR_OUTER_WIDTH = (
+  COLOR_BAR_LEFT_MARGIN + COLOR_BAR_WIDTH + COLOR_BAR_RIGHT_MARGIN
+);
+const COLOR_BAR_WIDGET_SIZE = (
+   COLOR_BAR_OUTER_WIDTH + COLOR_BAR_AXIS_WIDTH
+);
+
 @component('labrad-plot')
 export class Plot extends polymer.Base {
 
@@ -83,7 +95,7 @@ export class Plot extends polymer.Base {
   };
   private margin = {
     top: 50,
-    right: 80,
+    right: 10,
     bottom: 50,
     left: 40
   };
@@ -137,8 +149,9 @@ export class Plot extends polymer.Base {
       area: HTMLElement, totWidth: number, totHeight: number): void {
     const p = this;
 
-    if (p.numIndeps == 1) {
-      p.margin.right = 10;
+    // Make room for the color bar if necessary.
+    if (p.numIndeps == 2) {
+      p.margin.right += COLOR_BAR_WIDGET_SIZE;
     }
 
     const width = totWidth - p.margin.left - p.margin.right;
@@ -243,6 +256,7 @@ export class Plot extends polymer.Base {
               .ticks(7)
               .tickSize(5);
 
+      // The Color Bar Gradient
       p.svg.append('defs').append("linearGradient")
           .attr("id", "grads")
           .attr("x1", "0%")
@@ -260,19 +274,22 @@ export class Plot extends polymer.Base {
           .attr("stop-color", function(d) { return d.color; })
           .attr("stop-opacity", 1);
 
+      // Color Bar Rectangle
+      const colorBarOffset = width + COLOR_BAR_LEFT_MARGIN;
       p.svg.append('rect')
           .attr('fill', "url('" + location.href + "#grads')")
-          .attr('transform', `translate(${width + 15}, 0)`)
-          .attr('width', 15)
+          .attr('transform', `translate(${colorBarOffset}, 0)`)
+          .attr('width', COLOR_BAR_WIDTH)
           .attr('height', height)
-          .attr('stroke-width', .75)
+          .attr('stroke-width', COLOR_BAR_STROKE_WIDTH)
           .attr('stroke', '#000000');
 
-      // z-axis ticks and label
+      // Z-axis ticks and label.
+      const zAxisOffset = width + COLOR_BAR_LEFT_MARGIN + COLOR_BAR_WIDTH + COLOR_BAR_RIGHT_MARGIN;
       p.svg.append('g')
-              .attr('class', 'z axis')
-              .attr('transform', `translate(${width + 15 + 20}, 0)`)
-              .call(p.zAxis);
+           .attr('class', 'z axis')
+           .attr('transform', `translate(${zAxisOffset}, 0)`)
+           .call(p.zAxis);
     }
   }
 

--- a/client-js/app/elements/labrad-plot.ts
+++ b/client-js/app/elements/labrad-plot.ts
@@ -700,16 +700,9 @@ export class Plot extends polymer.Base {
    * Reset to original window size after zoom-in.
    */
   public resetZoom() {
-    var zMin = this.dataLimits.zMin,
-        zMax = this.dataLimits.zMax;
-    if (zMin == zMax) {
-      zMin -= 1;
-      zMax += 1;
-    }
-
     this.xScale.domain([this.limits.xMin, this.limits.xMax]);
     this.yScale.domain([this.limits.yMin, this.limits.yMax]);
-    this.zScale.domain([zMin, zMax]);
+    this.zScale.domain([this.dataLimits.zMin, this.dataLimits.zMax]);
     this.xAxis.scale(this.xScale);
     this.yAxis.scale(this.yScale);
     this.zAxis.scale(this.zScale);

--- a/client-js/app/elements/labrad-plot.ts
+++ b/client-js/app/elements/labrad-plot.ts
@@ -276,13 +276,13 @@ export class Plot extends polymer.Base {
             {offset: "100%", color: COLOR_MAP[255]}
           ])
           .enter().append("stop")
-          .attr("offset", function(d) { return d.offset; })
-          .attr("stop-color", function(d) { return d.color; })
+          .attr("offset", (d) => d.offset)
+          .attr("stop-color", (d) => d.color)
           .attr("stop-opacity", 1);
 
       // Appending the location href is necessary due to the use of `base href`
       // for the overall app to make Polymer paths work.
-      const gradientFill = "url('" + location.href + "#ColorBarGradient')";
+      const gradientFill = `url('${location.href}#ColorBarGradient')`;
 
       // Color Bar Rectangle
       const colorBarOffset = width + COLOR_BAR_LEFT_MARGIN;

--- a/client-js/app/elements/labrad-plot.ts
+++ b/client-js/app/elements/labrad-plot.ts
@@ -38,6 +38,11 @@ const COLOR_BAR_WIDGET_SIZE = (
    COLOR_BAR_OUTER_WIDTH + COLOR_BAR_AXIS_WIDTH
 );
 
+const PLOT_LEFT_MARGIN = 40;
+const PLOT_RIGHT_MARGIN = 10;
+const PLOT_TOP_MARGIN = 50;
+const PLOT_BOTTOM_MARGIN = 50;
+
 @component('labrad-plot')
 export class Plot extends polymer.Base {
 
@@ -94,10 +99,10 @@ export class Plot extends polymer.Base {
     zMax: NaN
   };
   private margin = {
-    top: 50,
-    right: 10,
-    bottom: 50,
-    left: 40
+    top: PLOT_TOP_MARGIN,
+    right: PLOT_RIGHT_MARGIN,
+    bottom: PLOT_BOTTOM_MARGIN,
+    left: PLOT_LEFT_MARGIN
   };
 
   // Hack to enforce user defined display of traces.
@@ -151,7 +156,7 @@ export class Plot extends polymer.Base {
 
     // Make room for the color bar if necessary.
     if (p.numIndeps == 2) {
-      p.margin.right += COLOR_BAR_WIDGET_SIZE;
+      p.margin.right = PLOT_RIGHT_MARGIN + COLOR_BAR_WIDGET_SIZE;
     }
 
     const width = totWidth - p.margin.left - p.margin.right;

--- a/client-js/app/elements/labrad-plot.ts
+++ b/client-js/app/elements/labrad-plot.ts
@@ -648,6 +648,7 @@ export class Plot extends polymer.Base {
         rect = this.svg.append('rect')
                        .classed('zoom', true)
                        .attr('stroke', 'red')
+                       .attr('fill', '#eee')
                        .attr('fill-opacity', 0.5);
 
     d3.select(window)

--- a/client-js/app/elements/labrad-plot.ts
+++ b/client-js/app/elements/labrad-plot.ts
@@ -258,7 +258,7 @@ export class Plot extends polymer.Base {
 
       // The Color Bar Gradient
       p.svg.append('defs').append("linearGradient")
-          .attr("id", "grads")
+          .attr("id", "ColorBarGradient")
           .attr("x1", "0%")
           .attr("y1", "0%")
           .attr("x2", "0%")
@@ -274,10 +274,14 @@ export class Plot extends polymer.Base {
           .attr("stop-color", function(d) { return d.color; })
           .attr("stop-opacity", 1);
 
+      // Appending the location href is necessary due to the use of `base href`
+      // for the overall app to make Polymer paths work.
+      const gradientFill = "url('" + location.href + "#ColorBarGradient')";
+
       // Color Bar Rectangle
       const colorBarOffset = width + COLOR_BAR_LEFT_MARGIN;
       p.svg.append('rect')
-          .attr('fill', "url('" + location.href + "#grads')")
+          .attr('fill', gradientFill)
           .attr('transform', `translate(${colorBarOffset}, 0)`)
           .attr('width', COLOR_BAR_WIDTH)
           .attr('height', height)

--- a/client-js/app/elements/labrad-plot.ts
+++ b/client-js/app/elements/labrad-plot.ts
@@ -83,7 +83,7 @@ export class Plot extends polymer.Base {
   };
   private margin = {
     top: 50,
-    right: 10,
+    right: 80,
     bottom: 50,
     left: 40
   };

--- a/client-js/app/elements/labrad-plot.ts
+++ b/client-js/app/elements/labrad-plot.ts
@@ -26,6 +26,7 @@ const COLOR_MAP = viridisData.map((rgb) => {
 });
 
 
+const COLOR_BAR_NUM_TICKS = 10;
 const COLOR_BAR_WIDTH = 15;
 const COLOR_BAR_LEFT_MARGIN = 15;
 const COLOR_BAR_RIGHT_MARGIN = 5;
@@ -256,29 +257,37 @@ export class Plot extends polymer.Base {
 
     // Color Bar Axis
     if (this.numIndeps == 2) {
-      p.zAxis = d3.svg.axis()
-              .scale(p.zScale)
-              .orient('right')
-              .ticks(7)
-              .tickSize(5);
+      p.zAxis = d3.svg.axis();
+      p.zAxis.scale(p.zScale)
+             .orient('right')
+             .ticks(COLOR_BAR_NUM_TICKS)
+             .tickSize(5);
+
+      // Create accurate gradient stops of the viridis colormap.
+      const gradientTicks = [];
+      for (let i = 0; i <= 255; ++i) {
+        const index = i / 255 * 100;
+        gradientTicks.push({
+          offset: `${index}%`,
+          color: COLOR_MAP[i]
+        })
+      }
 
       // The Color Bar Gradient
-      p.svg.append('defs').append("linearGradient")
-          .attr("id", "ColorBarGradient")
-          .attr("x1", "0%")
-          .attr("y1", "100%")
-          .attr("x2", "0%")
-          .attr("y2", "0%")
-          .selectAll("stop")
-          .data([
-            {offset: "0%", color: COLOR_MAP[0]},
-            {offset: "50%", color: COLOR_MAP[128]},
-            {offset: "100%", color: COLOR_MAP[255]}
-          ])
-          .enter().append("stop")
-          .attr("offset", (d) => d.offset)
-          .attr("stop-color", (d) => d.color)
-          .attr("stop-opacity", 1);
+      p.svg.append('defs')
+             .append("linearGradient")
+             .attr("id", "ColorBarGradient")
+             .attr("x1", "0%")
+             .attr("y1", "100%")
+             .attr("x2", "0%")
+             .attr("y2", "0%")
+             .selectAll("stop")
+             .data(gradientTicks)
+             .enter()
+               .append("stop")
+                 .attr("offset", (d) => d.offset)
+                 .attr("stop-color", (d) => d.color)
+                 .attr("stop-opacity", 1);
 
       // Appending the location href is necessary due to the use of `base href`
       // for the overall app to make Polymer paths work.
@@ -287,19 +296,19 @@ export class Plot extends polymer.Base {
       // Color Bar Rectangle
       const colorBarOffset = width + COLOR_BAR_LEFT_MARGIN;
       p.svg.append('rect')
-          .attr('fill', gradientFill)
-          .attr('transform', `translate(${colorBarOffset}, 0)`)
-          .attr('width', COLOR_BAR_WIDTH)
-          .attr('height', height)
-          .attr('stroke-width', COLOR_BAR_STROKE_WIDTH)
-          .attr('stroke', '#000000');
+             .attr('fill', gradientFill)
+             .attr('transform', `translate(${colorBarOffset}, 0)`)
+             .attr('width', COLOR_BAR_WIDTH)
+             .attr('height', height)
+             .attr('stroke', '#000000')
+             .attr('stroke-width', COLOR_BAR_STROKE_WIDTH);
 
       // Z-axis ticks and label.
       const zAxisOffset = width + COLOR_BAR_LEFT_MARGIN + COLOR_BAR_WIDTH + COLOR_BAR_RIGHT_MARGIN;
       p.svg.append('g')
-           .attr('class', 'z axis')
-           .attr('transform', `translate(${zAxisOffset}, 0)`)
-           .call(p.zAxis);
+             .attr('class', 'z axis')
+             .attr('transform', `translate(${zAxisOffset}, 0)`)
+             .call(p.zAxis);
     }
   }
 

--- a/client-js/app/elements/labrad-plot.ts
+++ b/client-js/app/elements/labrad-plot.ts
@@ -35,9 +35,6 @@ export class Plot extends polymer.Base {
   @property({type: String, value: ''})
   yLabel: string;
 
-  @property({type: String, value: ''})
-  zLabel: string;
-
   @property({type: Number, value: 0})
   numIndeps: number;
 
@@ -140,6 +137,10 @@ export class Plot extends polymer.Base {
       area: HTMLElement, totWidth: number, totHeight: number): void {
     const p = this;
 
+    if (p.numIndeps == 1) {
+      p.margin.right = 10;
+    }
+
     const width = totWidth - p.margin.left - p.margin.right;
     const height = totHeight - p.margin.top - p.margin.bottom;
 
@@ -160,7 +161,6 @@ export class Plot extends polymer.Base {
 
     p.xAxis = d3.svg.axis()
             .scale(p.xScale)
-            .orient('bottom')
             .tickSize(-height);
 
     p.yAxis = d3.svg.axis()
@@ -168,12 +168,6 @@ export class Plot extends polymer.Base {
             .orient('left')
             .ticks(5)
             .tickSize(-width);
-
-    p.zAxis = d3.svg.axis()
-            .scale(p.zScale)
-            .orient('right')
-            .ticks(5)
-            .tickSize(25);
 
     p.line = d3.svg.line()
             .x((d) => p.xScale(d[0]))
@@ -189,28 +183,6 @@ export class Plot extends polymer.Base {
             .append('svg')
             .attr('width', width + p.margin.left + p.margin.right)
             .attr('height', height + p. margin.top + p.margin.bottom)
-
-    p.svg.append('defs').append("linearGradient")
-        .attr("id", "grads")
-        .attr("x1", "0%")
-        .attr("y1", "0%")
-        .attr("x2", "100%")
-        .attr("y2", "0%")
-      .selectAll("stop")
-        .data([
-          {offset: "0%", color: "#00ff00"},
-          {offset: "50%", color: "#0000ff"},
-          {offset: "100%", color: "#ff0000"}
-        ])
-      .enter().append("stop")
-        .attr("offset", function(d) { return d.offset; })
-        .attr("stop-color", function(d) { return d.color; })
-        .attr("stop-opacity", 1);
-
-    p.svg.append('rect')
-.attr('fill', "url('" + location.href + "#grads')")
-.attr('width', 50)
-.attr('height', height)
 
     p.svg = p.svg
             .append('g')
@@ -250,21 +222,6 @@ export class Plot extends polymer.Base {
             .style('text-anchor', 'middle')
             .text(this.yLabel);
 
-    // z-axis ticks and label
-    p.svg.append('g')
-            .attr('class', 'z axis')
-            .attr('transform', `translate(${width}, 0)`)
-            .call(p.zAxis);
-    p.svg.append('text')
-            .attr('id', 'z-label')
-            .attr('transform', 'rotate(90)')
-            .attr('y', this.width - p.margin.right)
-            .attr('x', this.height - (height / 2))
-            .attr('dy', '1em')
-            .attr('transform', `translate(${width}, 0)`)
-            .style('text-anchor', 'middle')
-            .text(this.zLabel);
-
     // Draw the graph object (from http://jsfiddle.net/KSAbK/)
     // This keeps the data from exceeding the limits of the plot.
     p.chartBody = p.svg.append('g')
@@ -276,6 +233,47 @@ export class Plot extends polymer.Base {
             .attr('y', 0)
             .attr('width', width)
             .attr('height', height);
+
+
+    // Color Bar Axis
+    if (this.numIndeps == 2) {
+      p.zAxis = d3.svg.axis()
+              .scale(p.zScale)
+              .orient('right')
+              .ticks(7)
+              .tickSize(5);
+
+      p.svg.append('defs').append("linearGradient")
+          .attr("id", "grads")
+          .attr("x1", "0%")
+          .attr("y1", "0%")
+          .attr("x2", "0%")
+          .attr("y2", "100%")
+          .selectAll("stop")
+          .data([
+            {offset: "0%", color: COLOR_MAP[0]},
+            {offset: "50%", color: COLOR_MAP[128]},
+            {offset: "100%", color: COLOR_MAP[255]}
+          ])
+          .enter().append("stop")
+          .attr("offset", function(d) { return d.offset; })
+          .attr("stop-color", function(d) { return d.color; })
+          .attr("stop-opacity", 1);
+
+      p.svg.append('rect')
+          .attr('fill', "url('" + location.href + "#grads')")
+          .attr('transform', `translate(${width + 15}, 0)`)
+          .attr('width', 15)
+          .attr('height', height)
+          .attr('stroke-width', .75)
+          .attr('stroke', '#000000');
+
+      // z-axis ticks and label
+      p.svg.append('g')
+              .attr('class', 'z axis')
+              .attr('transform', `translate(${width + 15 + 20}, 0)`)
+              .call(p.zAxis);
+    }
   }
 
 
@@ -546,7 +544,6 @@ export class Plot extends polymer.Base {
     // Zoom and pan axes.
     this.svg.select('.x.axis').call(this.xAxis);
     this.svg.select('.y.axis').call(this.yAxis);
-    this.svg.select('.z.axis').call(this.zAxis);
 
     switch (this.numIndeps) {
       case 1: this.zoomData1D_(); break;
@@ -572,6 +569,10 @@ export class Plot extends polymer.Base {
 
     let w = 0,
         h = 0;
+
+    // Rescale the color bar.
+    this.svg.select('.z.axis').call(this.zAxis);
+
     // Adjust size, position, and color of each data rect.
     switch (this.drawMode2D) {
     case 'dots':

--- a/client-js/app/elements/labrad-plot.ts
+++ b/client-js/app/elements/labrad-plot.ts
@@ -174,6 +174,7 @@ export class Plot extends polymer.Base {
 
     p.xAxis = d3.svg.axis()
             .scale(p.xScale)
+            .orient('bottom')
             .tickSize(-height);
 
     p.yAxis = d3.svg.axis()
@@ -193,7 +194,7 @@ export class Plot extends polymer.Base {
 
     // Plot area.
     p.svg = d3.select(area)
-            .append('svg')
+            .append('svg:svg')
             .attr('width', width + p.margin.left + p.margin.right)
             .attr('height', height + p. margin.top + p.margin.bottom)
 
@@ -202,7 +203,7 @@ export class Plot extends polymer.Base {
             .attr('transform', `translate(${p.margin.left}, ${p.margin.top})`);
 
     // Background rectangle.
-    p.svg.append('rect')
+    p.svg.append('svg:rect')
             .classed('background', true)
             .attr('stroke', 'black')
             .attr('stroke-width', 1)
@@ -239,7 +240,7 @@ export class Plot extends polymer.Base {
     // This keeps the data from exceeding the limits of the plot.
     p.chartBody = p.svg.append('g')
             .attr('clip-path', 'url(#clip)');
-    p.clip = p.svg.append('clipPath')
+    p.clip = p.svg.append('svg:clipPath')
             .attr('id', 'clip')
             .append('rect')
             .attr('x', 0)

--- a/client-js/app/elements/labrad-plot.ts
+++ b/client-js/app/elements/labrad-plot.ts
@@ -266,9 +266,9 @@ export class Plot extends polymer.Base {
       p.svg.append('defs').append("linearGradient")
           .attr("id", "ColorBarGradient")
           .attr("x1", "0%")
-          .attr("y1", "0%")
+          .attr("y1", "100%")
           .attr("x2", "0%")
-          .attr("y2", "100%")
+          .attr("y2", "0%")
           .selectAll("stop")
           .data([
             {offset: "0%", color: COLOR_MAP[0]},

--- a/client-js/app/elements/labrad-plot.ts
+++ b/client-js/app/elements/labrad-plot.ts
@@ -203,7 +203,7 @@ export class Plot extends polymer.Base {
             .attr('transform', `translate(${p.margin.left}, ${p.margin.top})`);
 
     // Background rectangle.
-    p.svg.append('svg:rect')
+    p.svg.append('rect')
             .classed('background', true)
             .attr('stroke', 'black')
             .attr('stroke-width', 1)
@@ -242,7 +242,7 @@ export class Plot extends polymer.Base {
             .attr('clip-path', 'url(#clip)');
     p.clip = p.svg.append('svg:clipPath')
             .attr('id', 'clip')
-            .append('rect')
+            .append('svg:rect')
             .attr('x', 0)
             .attr('y', 0)
             .attr('width', width)

--- a/client-js/app/styles/main.css
+++ b/client-js/app/styles/main.css
@@ -23,9 +23,6 @@ tbody tr:hover {
  * by d3 within a custom element. We've placed them here for now, until we can
  * understand and fix the problem with polymer/d3.
  */
-rect {
-  fill: #eee;
-}
 .axis path, .axis line {
   fill: none;
   stroke: #000;


### PR DESCRIPTION
Fixes issue #90 where there was no axis for the colors displayed on 2D plots using the Grapher.

Added a new element to 2D plots showing the z-axis as a color gradient. The scale adjusts as new data is introduced. Size and positioning can be tweaked via constants in the file.

Also moved the styling for the `zoomRectangle` from global CSS, to a local fill color on the SVG element. This was done because otherwise all rectangles had to be the same color.
