### PR TITLE
Fix error causing 1D plots not to render properly

### DIFF
--- a/client-js/app/elements/labrad-plot.ts
+++ b/client-js/app/elements/labrad-plot.ts
@@ -757,9 +757,13 @@ export class Plot extends polymer.Base {
     this.zScale.domain([this.dataLimits.zMin, this.dataLimits.zMax]);
     this.xAxis.scale(this.xScale);
     this.yAxis.scale(this.yScale);
-    this.zAxis.scale(this.zScale);
     this.zoom.x(this.xScale);
     this.zoom.y(this.yScale);
+
+    if (this.numIndeps == 2) {
+      this.zAxis.scale(this.zScale);
+    }
+
     this.handleZoom();
   }
 


### PR DESCRIPTION
PR #219 actually broke 1D plots because they do not have a zAxis defined. This fixes 1D plots in `master`.
