### PR TITLE
Make gulp `test` task run tests, and enable `npm test`.

### DIFF
--- a/client-js/gulpfile.js
+++ b/client-js/gulpfile.js
@@ -328,9 +328,10 @@ gulp.task('serve', ['bundle', 'insert-dev-config', 'styles', 'elements', 'images
   gulp.watch(['app/images/**/*'], reload);
 });
 
-gulp.task('jasmine-cmd',['bundle-test'], function() {
-  return gulp.src('.tmp/testing/spec-bundle.js')
- .pipe(jasmine());
+gulp.task('test', ['bundle-test'], function() {
+  return gulp
+    .src('.tmp/testing/spec-bundle.js')
+    .pipe(jasmine());
 });
 
 gulp.task('watch', function () {
@@ -340,7 +341,7 @@ gulp.task('watch', function () {
 });
 
 gulp.task('test-watch', function () {
-  gulp.watch(['app/{scripts,elements}/**/*.ts'], ['jasmine-cmd']);
+  gulp.watch(['app/{scripts,elements}/**/*.ts'], ['test']);
 });
 
 // Build and serve the output from the dist build
@@ -362,10 +363,6 @@ gulp.task('default', ['clean'], function (cb) {
     'vulcanize', 'precache',
     cb);
 });
-
-// Load tasks for web-component-tester
-// Adds tasks for `gulp test:local` and `gulp test:remote`
-try { require('web-component-tester').gulp.init(gulp); } catch (err) {}
 
 // Load custom tasks from the `tasks` directory
 try { require('require-dir')('tasks'); } catch (err) {}

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -5,9 +5,10 @@
   "repository": "labrad/scalabrad-web",
   "license": "MIT",
   "scripts": {
+    "bower": "bower",
     "gulp": "gulp",
     "jspm": "jspm",
-    "bower": "bower"
+    "test": "gulp test"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
`web-component-tester` was taking over the test task, but we're not using it at the moment so I removed it. If someone gets ambitious and decides to write tests for the custom elements, we can make the test task also run those tests.

Also hooked up `npm test` to run the gulp tests, since that is the npm convention, though not super important for us.
