### PR TITLE
Fix limits for live 1D plots to show all the data

### DIFF
--- a/client-js/app/elements/labrad-plot.ts
+++ b/client-js/app/elements/labrad-plot.ts
@@ -360,15 +360,6 @@ export class Plot extends polymer.Base {
 
   private plotData1D(data: number[][], lastData?: number[]) {
     // Update data limits.
-    this.dataLimits = {
-      xMin: NaN,
-      xMax: NaN,
-      yMin: NaN,
-      yMax: NaN,
-      zMin: NaN,
-      zMax: NaN
-    };
-
     for (let row of data) {
       let x = row[0];
       this.dataLimits.xMin = safeMin(this.dataLimits.xMin, x);


### PR DESCRIPTION
Fixes issue #233. 1D live plots were having the data bounds being reset to only show the last stream of data, rather than scaling to view the full plot like 2D plots.

Simply removed the limits reset occurring each time new 1D data points are plotted.
