### PR TITLE
Changed typings exports to use es6 defaults for d3 and THREE.

### DIFF
--- a/client-js/typings/d3/d3.d.ts
+++ b/client-js/typings/d3/d3.d.ts
@@ -3291,5 +3291,8 @@ declare module d3 {
 interface TouchList { }
 
 declare module 'd3' {
-    export = d3;
+    // Use es6-style default export
+    //export d3;
+    export var d3;
+    export { d3 as default };
 }

--- a/client-js/typings/three/three.d.ts
+++ b/client-js/typings/three/three.d.ts
@@ -6606,5 +6606,8 @@ declare namespace THREE {
 }
 
 declare module 'three' {
-    export = THREE;
+    // Use es6-style default export
+    //export THREE;
+    export var THREE;
+    export { THREE as default };
 }


### PR DESCRIPTION
In order to properly import external modules nicely, we need them to support ES6 export syntax. Updated the typings files for `d3` and `THREE` to use this export style.
