### PR TITLE
Shutdown plot render loop and remove event listeners on detach.

### DIFF
--- a/client-js/app/scripts/activities.ts
+++ b/client-js/app/scripts/activities.ts
@@ -359,7 +359,6 @@ export class DatasetActivity implements Activity {
   }
 
   async stop(): Promise<void> {
-    this.plot.finishRender = true;
     this.lifetime.close();
     await this.api.dataStreamClose({token: this.token});
   }


### PR DESCRIPTION
This ensures that we don't do unnecessary work or prevent the widget from getting GC'd after it is detached.

@adamcw 
