### PR TITLE
Updated Grapher menu styling and function.

### DIFF
--- a/client-js/app/elements/labrad-grapher.html
+++ b/client-js/app/elements/labrad-grapher.html
@@ -103,6 +103,20 @@
       width: auto;
       margin-left: auto;
     }
+    .item a {
+      text-decoration: none;
+    }
+    .item a span {
+      text-decoration: underline;
+    }
+    .item .back-link,
+    .item .back-link:visited {
+       color: #555;
+    }
+    .item .back-link:hover,
+    .item .back-link:visited:hover {
+      color: #3f51b5;
+    }
   </style>
   <template>
     <div id="outer">
@@ -120,15 +134,23 @@
                 <div class$='row [[computeSelectedClass(selected)]]'>
                   <div class="item">
                     <template is="dom-if" if="[[item.isParent]]">
-                      <iron-icon icon="arrow-back" item-icon></iron-icon>
+                      <a class='back-link' is="app-link" path="[[item.url]]" href="[[item.url]]">
+                        <iron-icon icon="arrow-back" item-icon></iron-icon>
+                        <span>[[item.name]]</span>
+                      </a>
                     </template>
                     <template is="dom-if" if="[[item.isDir]]">
-                      <iron-icon icon="folder" item-icon class="folder"></iron-icon>
+                      <a is="app-link" path="[[item.url]]" href="[[item.url]]">
+                        <iron-icon icon="folder" item-icon class="folder"></iron-icon>
+                        <span>[[item.name]]</span>
+                      </a>
                     </template>
                     <template is="dom-if" if="[[item.isDataset]]">
-                      <iron-icon icon="editor:insert-chart" item-icon class="dataset"></iron-icon>
+                      <a is="app-link" path="[[item.url]]" href="[[item.url]]">
+                        <iron-icon icon="editor:insert-chart" item-icon class="dataset"></iron-icon>
+                        <span>[[item.name]]</span>
+                      </a>
                     </template>
-                    <a is="app-link" path="[[item.url]]" href="[[item.url]]">[[item.name]]</a>
                   </div>
                   <div class="label-wide">
                     <template is="dom-if" if="[[item.starred]]">


### PR DESCRIPTION
Updated the Grapher menu to behave like the updated registry menu in Pull #202.
- Icons are now clickable as well as the text, including the back arrow.
- Back arrow is now always a dark grey color instead of turning purple.
