### PR TITLE
Fix 1D plots to properly adjust zoom level when changing traces.

### DIFF
--- a/client-js/app/elements/labrad-plot.ts
+++ b/client-js/app/elements/labrad-plot.ts
@@ -860,6 +860,11 @@ export class Plot extends polymer.Base {
     this.limits.yMin = isNaN(this.dataLimits.yMin) ? 0 : this.dataLimits.yMin;
     this.limits.yMax = isNaN(this.dataLimits.yMax + this.dy) ?
         0 : this.dataLimits.yMax + this.dy;
+
+    if (this.dataLimits.zMin === this.dataLimits.zMax) {
+      this.dataLimits.zMin -= 1;
+      this.dataLimits.zMax += 1;
+    }
   }
 
 

--- a/client-js/app/elements/labrad-plot.ts
+++ b/client-js/app/elements/labrad-plot.ts
@@ -367,7 +367,17 @@ export class Plot extends polymer.Base {
 
     this.lastData = null;
 
+    this.dataLimits.xMin = 0;
+    this.dataLimits.xMax = 0;
+    this.dataLimits.yMin = 0;
+    this.dataLimits.yMax = 0;
+
     this.plotData(this.data);
+
+    if (!this.haveZoomed) {
+      this.resetZoomRequired = true;
+      this.updateScalesRequired = true;
+    }
 
     this.graphUpdateRequired = true;
   }

--- a/client-js/app/elements/labrad-plot.ts
+++ b/client-js/app/elements/labrad-plot.ts
@@ -367,10 +367,12 @@ export class Plot extends polymer.Base {
 
     this.lastData = null;
 
-    this.dataLimits.xMin = 0;
-    this.dataLimits.xMax = 0;
-    this.dataLimits.yMin = 0;
-    this.dataLimits.yMax = 0;
+    this.dataLimits.xMin = NaN;
+    this.dataLimits.xMax = NaN;
+    this.dataLimits.yMin = NaN;
+    this.dataLimits.yMax = NaN;
+    this.dataLimits.zMin = NaN;
+    this.dataLimits.zMax = NaN;
 
     this.plotData(this.data);
 
@@ -379,6 +381,7 @@ export class Plot extends polymer.Base {
       this.updateScalesRequired = true;
     }
 
+    this.updateColorBarScaleRequired = true;
     this.graphUpdateRequired = true;
   }
 

--- a/server/src/test/scripts/data_demo.py
+++ b/server/src/test/scripts/data_demo.py
@@ -45,11 +45,12 @@ def demo_1d_multi_high_variance(dv):
             'y (4) [nV]', 'y (5) [nV]', 'y (6) [nV]'])
     add_params(dv)
     amplitudes = [15, 1, 3, 5, 7, 9]
+    offsets = [100, -50, 10, 0, 0, 0]
     for i in xrange(1000):
         x = i / 100
         row = [x]
         for i in range(6):
-            y = 5 * amplitudes[i] * math.sin(x + math.pi * i/5) + random.random() - 0.5
+            y = 5 * amplitudes[i] * math.sin(x + math.pi * i/5) + offsets[i] + random.random() - 0.5
             row.append(y)
         dv.add(row)
         time.sleep(0.002)

--- a/server/src/test/scripts/data_demo.py
+++ b/server/src/test/scripts/data_demo.py
@@ -44,7 +44,7 @@ def demo_1d_multi_high_variance(dv):
            ['y (1) [nV]', 'y (2) [nV]', 'y (3) [nV]',
             'y (4) [nV]', 'y (5) [nV]', 'y (6) [nV]'])
     add_params(dv)
-    amplitudes = [10*random.random() for x in range(6)]
+    amplitudes = [15, 1, 3, 5, 7, 9]
     for i in xrange(1000):
         x = i / 100
         row = [x]

--- a/server/src/test/scripts/data_demo.py
+++ b/server/src/test/scripts/data_demo.py
@@ -36,6 +36,7 @@ def demo_1d_simple(dv):
         dv.add([x, y])
         time.sleep(0.002)
 
+
 @demo
 def demo_1d_multi_high_variance(dv):
     dv.new('demo_1d_high_var',
@@ -54,6 +55,7 @@ def demo_1d_multi_high_variance(dv):
         dv.add(row)
         time.sleep(0.002)
 
+
 @demo
 def demo_1d_multi(dv):
     dv.new('demo_1d_multi',
@@ -70,6 +72,7 @@ def demo_1d_multi(dv):
         dv.add(row)
         time.sleep(0.002)
 
+
 @demo
 def demo_2d_simple(dv):
     dv.new('demo_2d_simple', ['x [GHz]', 'y [V]'], ['z [a.u.]'])
@@ -81,6 +84,7 @@ def demo_2d_simple(dv):
             z = 5 * math.cos((x**2 + y**2) / 10) + random.random() - 0.5
             dv.add([x, y, z])
             time.sleep(0.002)
+
 
 @demo
 def demo_2d_multi(dv):
@@ -95,6 +99,7 @@ def demo_2d_multi(dv):
             z2 = 5 * 0
             dv.add([x, y, z1, z2])
             time.sleep(0.002)
+
 
 @demo
 def demo_2d_vargrid(dv):

--- a/server/src/test/scripts/data_demo.py
+++ b/server/src/test/scripts/data_demo.py
@@ -36,7 +36,6 @@ def demo_1d_simple(dv):
         dv.add([x, y])
         time.sleep(0.002)
 
-
 @demo
 def demo_1d_multi_high_variance(dv):
     dv.new('demo_1d_high_var',
@@ -71,7 +70,6 @@ def demo_1d_multi(dv):
         dv.add(row)
         time.sleep(0.002)
 
-
 @demo
 def demo_2d_simple(dv):
     dv.new('demo_2d_simple', ['x [GHz]', 'y [V]'], ['z [a.u.]'])
@@ -97,7 +95,6 @@ def demo_2d_multi(dv):
             z2 = 5 * 0
             dv.add([x, y, z1, z2])
             time.sleep(0.002)
-
 
 @demo
 def demo_2d_vargrid(dv):

--- a/server/src/test/scripts/data_demo.py
+++ b/server/src/test/scripts/data_demo.py
@@ -38,6 +38,23 @@ def demo_1d_simple(dv):
 
 
 @demo
+def demo_1d_multi_high_variance(dv):
+    dv.new('demo_1d_high_var',
+           ['x [ms]'],
+           ['y (1) [nV]', 'y (2) [nV]', 'y (3) [nV]',
+            'y (4) [nV]', 'y (5) [nV]', 'y (6) [nV]'])
+    add_params(dv)
+    amplitudes = [10*random.random() for x in range(6)]
+    for i in xrange(1000):
+        x = i / 100
+        row = [x]
+        for i in range(6):
+            y = 5 * amplitudes[i] * math.sin(x + math.pi * i/5) + random.random() - 0.5
+            row.append(y)
+        dv.add(row)
+        time.sleep(0.002)
+
+@demo
 def demo_1d_multi(dv):
     dv.new('demo_1d_multi',
            ['x [ms]'],


### PR DESCRIPTION
Fixes issue #242 where 1D plots do not re-zoom to properly frame the data when traces are toggled on and off.

Includes an update to `data_demo.py` to create sine waves with enough amplitude variance to test this feature in the future to avoid further regressions.
