### PR TITLE
Fix registry modal sizing when working with very long keys.

### DIFF
--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -75,6 +75,9 @@
       color: black;
     }
 
+    paper-dialog {
+      overflow-y: auto;
+    }
     paper-dialog.size-position {
       position: fixed;
       top: 16p
@@ -230,26 +233,22 @@
     <!-- Dialogs for various registry operations -->
 
     <paper-dialog id="newKeyDialog" modal>
-      <h1>Create new key</h1>
-      <paper-dialog-scrollable>
-        <form>
-          <paper-input id="newKeyInput" label="Key"></paper-input>
-          <paper-textarea id="newValueInput" label="Value"></paper-textarea>
-        </form>
-      </paper-dialog-scrollable>
-      <div class="buttons"> 
+      <h1>Create New Key</h1>
+      <form>
+        <paper-input id="newKeyInput" label="Key"></paper-input>
+        <paper-textarea id="newValueInput" label="Value"></paper-textarea>
+      </form>
+      <div class="buttons">
         <paper-button on-click="doNewKey" dialog-confirm>OK</paper-button>
         <paper-button dialog-dismiss>CANCEL</paper-button>
       </div>
     </paper-dialog>
 
     <paper-dialog id="editValueDialog" modal>
-      <h1>Edit: <span>{{selectedItem}}</span></h1>
-      <paper-dialog-scrollable>
-        <form>
-          <paper-textarea id="editValueInput" label="Value"></paper-textarea>
-        </form>
-      </paper-dialog-scrollable>
+      <h1>Edit <span>{{selectedItem}}</span></h1>
+      <form>
+        <paper-textarea id="editValueInput" label="Value"></paper-textarea>
+      </form>
       <div class="buttons">
         <paper-button on-click="doEditValue" dialog-confirm autofocus>OK</paper-button>
         <paper-button dialog-dismiss>CANCEL</paper-button>
@@ -257,7 +256,7 @@
     </paper-dialog>
 
     <paper-dialog id="newFolderDialog" modal>
-      <h1>Create new folder</h1>
+      <h1>Create New Folder</h1>
       <form>
         <paper-input id="newFolderInput" label="Name"></paper-input>
       </form>
@@ -311,7 +310,7 @@
     </paper-dialog>
 
     <paper-dialog id="pendingDialog" modal>
-      <h1 id="pendingOp"></h1> 
+      <h1 id="pendingOp"></h1>
     </paper-dialog>
 
     <paper-toast id="toastCopySuccess" text="Copy Successful!" duration=3000></paper-toast>

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -33,6 +33,15 @@ export class LabradRegistry extends polymer.Base {
 
   regex: RegExp; //regular expression for string comparison
 
+
+  attached() {
+    this.bindIronAutogrowTextAreaResizeEvents(this.$.newKeyDialog,
+                                              this.$.newValueInput);
+
+    this.bindIronAutogrowTextAreaResizeEvents(this.$.editValueDialog,
+                                              this.$.editValueInput);
+  }
+
   /**
    * on a path change, we deselect everything, empty filterText
    */
@@ -270,15 +279,8 @@ export class LabradRegistry extends polymer.Base {
    */
   bindIronAutogrowTextAreaResizeEvents(paperDialog: HTMLElement,
                                        ironAutogrowTextarea: HTMLElement) {
-    var resizeOnValueChange = function() {
+    ironAutogrowTextarea.addEventListener('bind-value-changed', () => {
       Polymer.Base.fire("iron-resize", null, {node: ironAutogrowTextarea});
-    };
-
-    ironAutogrowTextarea.addEventListener('bind-value-changed', resizeOnValueChange);
-
-    // Hook dialog close event to clean up the listener.
-    paperDialog.addEventListener('iron-overlay-closed', () => {
-      ironAutogrowTextarea.removeEventListener('bind-value-changed', resizeOnValueChange);
     });
   }
 
@@ -292,8 +294,6 @@ export class LabradRegistry extends polymer.Base {
     newKeyElem.value = '';
     newValueElem.value = '';
     dialog.open();
-
-    this.bindIronAutogrowTextAreaResizeEvents(dialog, newValueElem);
   }
 
   /**
@@ -340,8 +340,6 @@ export class LabradRegistry extends polymer.Base {
     editValueElem.value = value;
     dialog.keyName = name;
     dialog.open();
-
-    this.bindIronAutogrowTextAreaResizeEvents(dialog, editValueElem);
   }
 
   /**

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -261,6 +261,28 @@ export class LabradRegistry extends polymer.Base {
   }
 
   /**
+   * Bind event listeners to resize dialog box appropriately when an
+   * `iron-autogrow-textarea` is used.
+   *
+   * This works around an issue where it does not fire an `iron-resize` event
+   * when the value updates, and hence a `paper-dialog` is not informed to
+   * update its size or position to accomodate the change in content size.
+   */
+  bindIronAutogrowTextAreaResizeEvents(paperDialog: HTMLElement,
+                                       ironAutogrowTextarea: HTMLElement) {
+    var resizeOnValueChange = function() {
+      Polymer.Base.fire("iron-resize", null, {node: ironAutogrowTextarea});
+    };
+
+    ironAutogrowTextarea.addEventListener('bind-value-changed', resizeOnValueChange);
+
+    // Hook dialog close event to clean up the listener.
+    paperDialog.addEventListener('iron-overlay-closed', () => {
+      ironAutogrowTextarea.removeEventListener('bind-value-changed', resizeOnValueChange);
+    });
+  }
+
+  /**
    * Launch new key dialog.
    */
   newKeyClicked(event) {
@@ -270,7 +292,8 @@ export class LabradRegistry extends polymer.Base {
     newKeyElem.value = '';
     newValueElem.value = '';
     dialog.open();
-    window.setTimeout(() => newKeyElem.$.input.focus(), 0);
+
+    this.bindIronAutogrowTextAreaResizeEvents(dialog, newValueElem);
   }
 
   /**
@@ -317,7 +340,8 @@ export class LabradRegistry extends polymer.Base {
     editValueElem.value = value;
     dialog.keyName = name;
     dialog.open();
-    window.setTimeout(() => editValueElem.$.input.$.textarea.focus(), 0);
+
+    this.bindIronAutogrowTextAreaResizeEvents(dialog, editValueElem);
   }
 
   /**


### PR DESCRIPTION
Fixes #244 where very long registry keys would scroll off the page due to the dialog not resizing properly.

This PR also fixes the unreported issue that if you pasted a long key into the new key or edit key windows, the modal window would not reposition, causing it to go off screen.

This bug was caused by an interplay of the various Polymer elements being used. The main culprit being that the `iron-resize` event that `paper-dialog` listens to so that it knows when to resize/reposition does not get fired by a `iron-autogrow-textarea` which is a lower level component that `paper-textarea` wraps.

This is resolved by first simplifying the component interaction stack by removing the use on `paper-dialog-scrollable` and moving the job of scrolling to the dialog itself. Secondly, the value update event on the textarea is hooked, and used to fire an `iron-resize` event that the dialog can catch, causing both the position and sizing to be set correctly.
