### PR TITLE
Added close buttons to the manager to kill connections.

### DIFF
--- a/client-js/app/elements/labrad-manager.html
+++ b/client-js/app/elements/labrad-manager.html
@@ -55,10 +55,10 @@
             <td><span>{{item.id}}</span></td>
             <td>
               <template is="dom-if" if="{{item.server}}">
-                <span>server</span>
+                <span>Server</span>
               </template>
               <template is="dom-if" if="{{!item.server}}">
-                <span>client</span>
+                <span>Client</span>
               </template>
             </td>
             <td>
@@ -77,10 +77,26 @@
             <td><span>{{item.clientRespCount}}</span></td>
             <td><span>{{item.msgSendCount}}</span></td>
             <td><span>{{item.msgRecvCount}}</span></td>
-            <td class='close'><span><a href='#close{{item.id}}' conn-id='{{item.id}}' on-click='closeConnection'>×</span></td>
+            <td class='close'>
+              <span>
+                <a href='#closeConnection:{{item.id}}'
+                   conn-id='{{item.id}}'
+                   conn-name='{{item.name}}'
+                   on-tap='closeConnection'>×</a>
+              </span>
+            </td>
           </tr>
         </template>
       </tbody>
     </table>
+    <paper-dialog id="closeConnectionConfirmation" modal>
+      <h1>Close Connection</h1>
+      <p>Are you sure you want to close the connection to {{selectedConnection.name}}?</p>
+      <div class="buttons">
+        <paper-button on-tap="closeConnectionConfirmed"
+                      dialog-confirm autofocus>Yes</paper-button>
+        <paper-button dialog-dismiss>No</paper-button>
+      </div>
+    </paper-dialog>
   </template>
 </dom-module>

--- a/client-js/app/elements/labrad-manager.html
+++ b/client-js/app/elements/labrad-manager.html
@@ -26,6 +26,12 @@
     tbody tr:nth-child(even):hover {
       background-color: #FFFFAA;
     }
+    .close {
+      text-align: center;
+    }
+    .close a:hover {
+      color: #f00;
+    }
   </style>
   <template>
     <table>
@@ -40,6 +46,7 @@
           <th>Client Reps</th>
           <th>Messages Sent</th>
           <th>Messages Recv</th>
+          <th class='close'>Close</th>
         </tr>
       </thead>
       <tbody>
@@ -70,6 +77,7 @@
             <td><span>{{item.clientRespCount}}</span></td>
             <td><span>{{item.msgSendCount}}</span></td>
             <td><span>{{item.msgRecvCount}}</span></td>
+            <td class='close'><span><a href='#close{{item.id}}' conn-id='{{item.id}}' on-click='closeConnection'>×</span></td>
           </tr>
         </template>
       </tbody>

--- a/client-js/app/elements/labrad-manager.html
+++ b/client-js/app/elements/labrad-manager.html
@@ -32,6 +32,11 @@
     .close a:hover {
       color: #f00;
     }
+    p.connection {
+      text-align: center;
+      font-weight: 800;
+      margin-top: 0px;
+    }
   </style>
   <template>
     <table>
@@ -91,7 +96,8 @@
     </table>
     <paper-dialog id="closeConnectionConfirmation" modal>
       <h1>Close Connection</h1>
-      <p>Are you sure you want to close the connection to {{selectedConnection.name}}?</p>
+      <p>Are you sure you want to close the connection?</p>
+      <p class='connection'>({{selectedConnection.connId}}) {{selectedConnection.name}}</p>
       <div class="buttons">
         <paper-button on-tap="closeConnectionConfirmed"
                       dialog-confirm autofocus>Yes</paper-button>

--- a/client-js/app/elements/labrad-manager.ts
+++ b/client-js/app/elements/labrad-manager.ts
@@ -1,4 +1,4 @@
-import {ConnectionInfo} from '../scripts/manager';
+import {ConnectionInfo, ManagerApi} from '../scripts/manager';
 
 @component('labrad-manager')
 export class LabradManager extends polymer.Base {
@@ -6,4 +6,9 @@ export class LabradManager extends polymer.Base {
   @property({type: Array, notify: true})
   connections: Array<ConnectionInfo>;
 
+  mgr: ManagerApi;
+
+  closeConnection(event) {
+    this.mgr.connectionClose(event.currentTarget.connId);
+  }
 }

--- a/client-js/app/elements/labrad-manager.ts
+++ b/client-js/app/elements/labrad-manager.ts
@@ -6,9 +6,36 @@ export class LabradManager extends polymer.Base {
   @property({type: Array, notify: true})
   connections: Array<ConnectionInfo>;
 
+  @property({type: Object, notify: true})
+  selectedConnection: {connId: number, name: string};
+
   mgr: ManagerApi;
 
   closeConnection(event) {
-    this.mgr.connectionClose(event.currentTarget.connId);
+    this.selectedConnection = {
+      connId: event.currentTarget.connId,
+      name: event.currentTarget.connName
+    };
+
+    const dialog = this.$.closeConnectionConfirmation;
+    dialog.open();
+
+    event.preventDefault();
+  }
+
+  closeConnectionConfirmed() {
+    const id = this.selectedConnection.connId;
+
+    this.mgr.connectionClose(id);
+    this.selectedConnection = null;
+
+    // Remove the connection from the array to notify the UI
+    const numConnections = this.connections.length;
+    for (let i = 0; i < numConnections; ++i) {
+      if (this.connections[i].id == id) {
+        this.splice('connections', i, 1);
+        break;
+      }
+    }
   }
 }

--- a/client-js/app/scripts/activities.ts
+++ b/client-js/app/scripts/activities.ts
@@ -379,6 +379,7 @@ export class ManagerActivity implements Activity {
     });
     var elem = <LabradManager> LabradManager.create();
     elem.connections = connsWithUrl;
+    elem.mgr = this.api;
     return {
       elem: elem,
       route: 'manager'


### PR DESCRIPTION
Fix #247. Implements a close button for each connection on the Manager screen that will kill that connection. 

Allows for the killing of servers that have detached from nodes without having to hunt them down manually.
