### PR TITLE
Show exceptions on Nodes when they occur during start, stop or restart of a server.

### DIFF
--- a/client-js/app/elements/labrad-nodes.html
+++ b/client-js/app/elements/labrad-nodes.html
@@ -2,6 +2,51 @@
 <link rel="import" href="../bower_components/paper-icon-button/paper-icon-button.html">
 <link rel="import" href="../bower_components/paper-spinner/paper-spinner.html">
 
+<dom-module id="labrad-exception-handler">
+  <style>
+    :host {
+      display: table-row;
+    }
+    td {
+      font-family: "Roboto Regular", sans-serif;
+      font-size: 14px;
+      padding: 7px;
+      color: #F44336;
+      font-weight: 800;
+      background-color: #fff;
+      border-top: 2px solid #f44336;
+    }
+    div.exceptionCollapse {
+      padding: 5px 15px;
+      word-wrap: wrap;
+      font-size: 13px;
+      font-weight: 400;
+    }
+    div.exceptionCollapse span {
+      font-weight: 800;
+    }
+    div.exception {
+      padding: 10px;
+      font-size: 12px;
+      font-weight: 400;
+    }
+  </style>
+  <template>
+    <template is="dom-if" if="{{error}}">
+      <td colspan="3">
+        {{error}}
+
+        <div class="exceptionCollapse">
+          <div><span>Exception</span> <paper-button on-click="toggleException">Show/Hide</paper-button></div>
+          <iron-collapse id="exceptionCollapse">
+            <div class='exception'>{{exception}}</div>
+          </iron-collapse>
+        </div>
+      </td>
+    </template>
+  </template>
+</dom-module>
+
 <dom-module id="labrad-instance-controller">
   <style>
     .divider {
@@ -36,6 +81,7 @@
         <paper-icon-button id="start" icon="av:play-arrow"></paper-icon-button>
         <paper-icon-button id="stop" icon="av:stop"></paper-icon-button>
         <paper-icon-button id="restart" icon="av:replay"></paper-icon-button>
+        <paper-icon-button id="autostartList" icon="av:play"></paper-icon-button>
       </span>
     </div>
   </template>
@@ -74,6 +120,7 @@
     }
     table {
       border-collapse: collapse;
+      width: 100%;
     }
     th {
       padding: 4px;
@@ -85,14 +132,23 @@
       background-color: #440088;
       color: white;
     }
-    tbody tr:nth-child(odd) {
+    tbody tr:nth-of-type(odd) {
       background-color: #EEEEEE;
     }
-    tbody tr:nth-child(odd):hover {
+    tbody tr:nth-of-type(odd):hover {
       background-color: #F6F699;
     }
-    tbody tr:nth-child(even):hover {
+    tbody tr:nth-of-type(even):hover {
       background-color: #FFFFAA;
+    }
+    td.name {
+      padding-left: 10px;
+    }
+    td.version {
+      width: 150px;
+    }
+    td.controls {
+      width: 350px;
     }
   </style>
   <template>
@@ -108,16 +164,17 @@
         <tbody>
           <template is="dom-repeat" items="{{globalServers}}" as="server">
             <tr>
-              <td>{{server.name}}</td>
-              <td>{{server.version}}</td>
+              <td class='name'>{{server.name}}</td>
+              <td class='version'>{{server.version}}</td>
               <template is="dom-repeat" items="{{server.nodes}}" as="node">
-                <td>
+                <td class='controls'>
                   <template is="dom-if" if="{{node.exists}}">
                     <labrad-instance-controller
                       places={{places}}
                       api={{api}}
                       local
                       name={{server.name}}
+                      server={{server}}
                       instance-name={{node.instanceName}}
                       node={{node.name}}
                       status={{node.status}} />
@@ -125,6 +182,9 @@
                 </td>
               </template>
             </tr>
+            <labrad-exception-handler
+              error="{{server.errorString}}"
+              exception="{{server.errorException}}" />
           </template>
         </tbody>
 
@@ -138,15 +198,16 @@
         <tbody>
           <template is="dom-repeat" items="{{localServers}}" as="server">
             <tr>
-              <td>{{server.name}}</td>
-              <td>{{server.version}}</td>
+              <td class='name'>{{server.name}}</td>
+              <td class='version'>{{server.version}}</td>
               <template is="dom-repeat" items="{{server.nodes}}" as="node">
-                <td>
+                <td class='controls'>
                   <template is="dom-if" if="{{node.exists}}">
                     <labrad-instance-controller
                       places={{places}}
                       api={{api}}
                       name={{server.name}}
+                      server={{server}}
                       instance-name={{node.instanceName}}
                       node={{node.name}}
                       status={{node.status}} />
@@ -154,6 +215,9 @@
                 </td>
               </template>
             </tr>
+            <labrad-exception-handler
+              error="{{server.errorString}}"
+              exception="{{server.errorException}}" />
           </template>
         </tbody>
       </table>

--- a/client-js/app/elements/labrad-nodes.html
+++ b/client-js/app/elements/labrad-nodes.html
@@ -30,14 +30,21 @@
       font-size: 12px;
       font-weight: 400;
     }
+    paper-button.dismiss {
+      float: right;
+    }
   </style>
   <template>
     <template is="dom-if" if="{{error}}">
-      <td colspan="3">
+      <td colspan="999">
         {{error}}
+        <paper-button class='dismiss' on-click="dismissException">Dismiss</paper-button>
 
         <div class="exceptionCollapse">
-          <div><span>Exception</span> <paper-button on-click="toggleException">Show/Hide</paper-button></div>
+          <div>
+            <span>Exception</span>
+            <paper-button on-click="toggleException">Show/Hide</paper-button>
+          </div>
           <iron-collapse id="exceptionCollapse">
             <div class='exception'>{{exception}}</div>
           </iron-collapse>

--- a/client-js/app/elements/labrad-nodes.html
+++ b/client-js/app/elements/labrad-nodes.html
@@ -81,7 +81,6 @@
         <paper-icon-button id="start" icon="av:play-arrow"></paper-icon-button>
         <paper-icon-button id="stop" icon="av:stop"></paper-icon-button>
         <paper-icon-button id="restart" icon="av:replay"></paper-icon-button>
-        <paper-icon-button id="autostartList" icon="av:play"></paper-icon-button>
       </span>
     </div>
   </template>

--- a/client-js/app/elements/labrad-nodes.ts
+++ b/client-js/app/elements/labrad-nodes.ts
@@ -3,6 +3,21 @@ import {ManagerApi, ServerConnectMessage, ServerDisconnectMessage} from '../scri
 import {NodeApi, NodeStatus, ServerStatus, ServerStatusMessage} from '../scripts/node';
 import {Places} from '../scripts/places';
 
+
+@component('labrad-exception-handler')
+export class LabradExceptionHandler extends polymer.Base {
+  @property({type: String, value: ''})
+  error: string;
+
+  @property({type: String, value: ''})
+  exception: string;
+
+  toggleException() {
+    const collapse = <any>(this.querySelector('#exceptionCollapse'));
+    collapse.toggle();
+  }
+}
+
 @component('labrad-instance-controller')
 export class LabradInstanceController extends polymer.Base {
   @property()
@@ -26,6 +41,9 @@ export class LabradInstanceController extends polymer.Base {
   @property({type: Boolean, value: false})
   active: boolean;
 
+  @property({type: Object, notify: true})
+  server: ServerInfo;
+
   @property()
   api: NodeApi;
 
@@ -46,23 +64,51 @@ export class LabradInstanceController extends polymer.Base {
     this.updateButtonState(newStatus);
   }
 
+
   @listen('start.click')
-  doStart() {
+  async doStart() {
     console.info(`Start: server='${this.name}', node='${this.node}'`);
-    this.api.startServer({node: this.node, server: this.name});
+    try {
+      await this.api.startServer({node: this.node, server: this.name});
+      this.set("server.errorString", "");
+      this.set("server.errorException", "");
+    } catch (e) {
+      console.error("Exception while starting server: ", e);
+      this.set("server.errorString", "An error occurred while starting the server.");
+      this.set("server.errorException", e.message);
+    }
   }
+
 
   @listen('stop.click')
-  doStop() {
+  async doStop() {
     console.info(`Stop: server='${this.name}', node='${this.node}'`);
-    this.api.stopServer({node: this.node, server: this.instanceName});
+    try {
+      await this.api.stopServer({node: this.node, server: this.instanceName});
+      this.set("server.errorString", "");
+      this.set("server.errorException", "");
+    } catch (e) {
+      console.error("Exception while stopping server: ", e);
+      this.set("server.errorString", "An error occurred while starting the server.");
+      this.set("server.errorException", e.message);
+    }
   }
 
+
   @listen('restart.click')
-  doRestart() {
+  async doRestart() {
     console.info(`Restart: server='${this.name}', node='${this.node}'`);
-    this.api.restartServer({node: this.node, server: this.instanceName});
+    try {
+      await this.api.restartServer({node: this.node, server: this.instanceName});
+      this.set("server.errorString", "");
+      this.set("server.errorException", "");
+    } catch (e) {
+      console.error("Exception while restarting server: ", e);
+      this.set("server.errorString", "An error occurred while starting the server.");
+      this.set("server.errorException", e.message);
+    }
   }
+
 
   statusChange(msg: ServerStatusMessage): void {
     if (this.name === msg.server) {
@@ -74,7 +120,7 @@ export class LabradInstanceController extends polymer.Base {
           case 'STOPPED': this.updateButtonState(this.status); break;
           case 'STARTING': this.updateButtonState('RUNNING_ELSEWHERE'); break;
           case 'STARTED': this.updateButtonState('RUNNING_ELSEWHERE'); break;
-          case 'STOPPPING': this.updateButtonState('RUNNING_ELSEWHERE'); break;
+          case 'STOPPING': this.updateButtonState('RUNNING_ELSEWHERE'); break;
         }
       }
     }
@@ -127,6 +173,8 @@ export class LabradNodeController extends polymer.Base {
     this.active = true;
     try {
       await this.api.refreshNode(this.name);
+    } catch (e) {
+      console.error("Exception while refreshing server: ", e);
     } finally {
       this.active = false;
     }
@@ -139,6 +187,8 @@ export class LabradNodeController extends polymer.Base {
 interface ServerInfo {
   name: string;
   version: string;
+  errorString: string;
+  errorException: string;
   nodes: Array<{name: string, exists: boolean, status?: string, instanceName?: string}>;
 }
 
@@ -318,6 +368,8 @@ export class LabradNodes extends polymer.Base {
       return {
         name: server,
         version: version,
+        errorString: '',
+        errorException: '',
         nodes: nodeNames.map((node) => {
           var status = statusMap.get(node).get(server);
           if (typeof status === 'undefined') {
@@ -350,6 +402,8 @@ export class LabradNodes extends polymer.Base {
       return {
         name: server,
         version: version,
+        errorString: '',
+        errorException: '',
         nodes: nodeNames.map((node) => {
           var status = statusMap.get(node).get(server);
           if (typeof status === 'undefined') {

--- a/client-js/app/elements/labrad-nodes.ts
+++ b/client-js/app/elements/labrad-nodes.ts
@@ -6,10 +6,10 @@ import {Places} from '../scripts/places';
 
 @component('labrad-exception-handler')
 export class LabradExceptionHandler extends polymer.Base {
-  @property({type: String, value: ''})
+  @property({type: String, value: '', notify: true})
   error: string;
 
-  @property({type: String, value: ''})
+  @property({type: String, value: '', notify: true})
   exception: string;
 
   toggleException() {
@@ -18,8 +18,8 @@ export class LabradExceptionHandler extends polymer.Base {
   }
 
   dismissException() {
-    this.error = '';
-    this.exception = '';
+    this.set('error', '');
+    this.set('exception', '');
   }
 }
 
@@ -75,13 +75,13 @@ export class LabradInstanceController extends polymer.Base {
     console.info(`Start: server='${this.name}', node='${this.node}'`);
     try {
       await this.api.startServer({node: this.node, server: this.name});
-      this.set("server.errorString", "");
-      this.set("server.errorException", "");
+      this.set('server.errorString', '');
+      this.set('server.errorException', '');
     } catch (e) {
       const message = `${this.instanceName} (${this.node}): An error occured while starting the server`;
       console.error(message, e);
-      this.set("server.errorString", message);
-      this.set("server.errorException", e.message);
+      this.set('server.errorString', message);
+      this.set('server.errorException', e.message);
     }
   }
 
@@ -91,13 +91,13 @@ export class LabradInstanceController extends polymer.Base {
     console.info(`Stop: server='${this.name}', node='${this.node}'`);
     try {
       await this.api.stopServer({node: this.node, server: this.instanceName});
-      this.set("server.errorString", "");
-      this.set("server.errorException", "");
+      this.set('server.errorString', '');
+      this.set('server.errorException', '');
     } catch (e) {
       const message = `${this.instanceName} (${this.node}): An error occured while stopping the server`;
       console.error(message, e);
-      this.set("server.errorString", message);
-      this.set("server.errorException", e.message);
+      this.set('server.errorString', message);
+      this.set('server.errorException', e.message);
     }
   }
 
@@ -107,13 +107,13 @@ export class LabradInstanceController extends polymer.Base {
     console.info(`Restart: server='${this.name}', node='${this.node}'`);
     try {
       await this.api.restartServer({node: this.node, server: this.instanceName});
-      this.set("server.errorString", "");
-      this.set("server.errorException", "");
+      this.set('server.errorString', '');
+      this.set('server.errorException', '');
     } catch (e) {
       const message = `${this.instanceName} (${this.node}): An error occured while restarting the server`;
       console.error(message, e);
-      this.set("server.errorString", message);
-      this.set("server.errorException", e.message);
+      this.set('server.errorString', message);
+      this.set('server.errorException', e.message);
     }
   }
 

--- a/client-js/app/elements/labrad-nodes.ts
+++ b/client-js/app/elements/labrad-nodes.ts
@@ -13,8 +13,13 @@ export class LabradExceptionHandler extends polymer.Base {
   exception: string;
 
   toggleException() {
-    const collapse = <any>(this.querySelector('#exceptionCollapse'));
+    const collapse: any = this.querySelector('#exceptionCollapse');
     collapse.toggle();
+  }
+
+  dismissException() {
+    this.error = '';
+    this.exception = '';
   }
 }
 
@@ -73,8 +78,9 @@ export class LabradInstanceController extends polymer.Base {
       this.set("server.errorString", "");
       this.set("server.errorException", "");
     } catch (e) {
-      console.error("Exception while starting server: ", e);
-      this.set("server.errorString", "An error occurred while starting the server.");
+      const message = `${this.instanceName} (${this.node}): An error occured while starting the server`;
+      console.error(message, e);
+      this.set("server.errorString", message);
       this.set("server.errorException", e.message);
     }
   }
@@ -88,8 +94,9 @@ export class LabradInstanceController extends polymer.Base {
       this.set("server.errorString", "");
       this.set("server.errorException", "");
     } catch (e) {
-      console.error("Exception while stopping server: ", e);
-      this.set("server.errorString", "An error occurred while starting the server.");
+      const message = `${this.instanceName} (${this.node}): An error occured while stopping the server`;
+      console.error(message, e);
+      this.set("server.errorString", message);
       this.set("server.errorException", e.message);
     }
   }
@@ -103,8 +110,9 @@ export class LabradInstanceController extends polymer.Base {
       this.set("server.errorString", "");
       this.set("server.errorException", "");
     } catch (e) {
-      console.error("Exception while restarting server: ", e);
-      this.set("server.errorString", "An error occurred while starting the server.");
+      const message = `${this.instanceName} (${this.node}): An error occured while restarting the server`;
+      console.error(message, e);
+      this.set("server.errorString", message);
       this.set("server.errorException", e.message);
     }
   }
@@ -174,7 +182,7 @@ export class LabradNodeController extends polymer.Base {
     try {
       await this.api.refreshNode(this.name);
     } catch (e) {
-      console.error("Exception while refreshing server: ", e);
+      console.error(`Exception while refreshing node: ${this.name}`, e);
     } finally {
       this.active = false;
     }

--- a/client-js/app/scripts/app.ts
+++ b/client-js/app/scripts/app.ts
@@ -18,7 +18,7 @@ import {LabradApp} from "../elements/labrad-app";
 import {LabradGrapher} from "../elements/labrad-grapher";
 import {LabradGrapherLive, LabeledPlot} from "../elements/labrad-grapher-live";
 import {LabradManager} from "../elements/labrad-manager";
-import {LabradNodes, LabradInstanceController, LabradNodeController} from "../elements/labrad-nodes";
+import {LabradExceptionHandler, LabradNodes, LabradInstanceController, LabradNodeController} from "../elements/labrad-nodes";
 import {LabradRegistry} from "../elements/labrad-registry";
 import {LabradServer} from "../elements/labrad-server";
 import {Plot} from "../elements/labrad-plot";
@@ -89,6 +89,7 @@ window.addEventListener('WebComponentsReady', () => {
   LabradRegistry.register();
   LabradNodes.register();
   LabradInstanceController.register();
+  LabradExceptionHandler.register();
   LabradNodeController.register();
   LabradServer.register();
   Plot.register();

--- a/client-js/app/scripts/node.ts
+++ b/client-js/app/scripts/node.ts
@@ -57,9 +57,11 @@ export class NodeService extends rpc.RpcService implements NodeApi {
   restartServer(params: {node: string; server: string}): Promise<void> {
     return this.call<void>('restartServer', params);
   }
+
   startServer(params: {node: string; server: string}): Promise<void> {
     return this.call<void>('startServer', params);
   }
+
   stopServer(params: {node: string; server: string}): Promise<void> {
     return this.call<void>('stopServer', params);
   }


### PR DESCRIPTION
Fixes #169. Shows the user that an error has occurred if an exception is thrown during the starting, stopping or resetting of a server from the Node panel. Also show the whole exception that was raised in a collapsible panel.

Previously, when an exception occurred while starting, stopping or resetting a server, it was logged to the console, but not displayed to the user.

Also adjusts the Node UI to fill the screen and fixes the "jump" that would occur when the loading spinner was active on a line of controls.
