### PR TITLE
Convert Remaining JavaScript Components to TypeScript

### DIFF
--- a/client-js/app/elements/labrad-breadcrumbs.html
+++ b/client-js/app/elements/labrad-breadcrumbs.html
@@ -50,17 +50,3 @@
     </ul>
   </template>
 </dom-module>
-
-<script>
-(function () {
-  Polymer({
-    is: 'labrad-breadcrumbs',
-    properties: {
-      breadcrumbs: {
-        type: Array,
-        notify: true
-      }
-    }
-  });
-})();
-</script>

--- a/client-js/app/elements/labrad-breadcrumbs.ts
+++ b/client-js/app/elements/labrad-breadcrumbs.ts
@@ -1,0 +1,8 @@
+@component('labrad-breadcrumbs')
+export class LabradBreadcrumbs extends polymer.Base {
+  @property({type: Array, notify: true})
+  breadcrumbs: Array<{name: string; isLink: boolean; url?: string}>;
+
+  @property({type: Array, notify: true})
+  extras: Array<{name: string; isLink: boolean; url?: string}>;
+}

--- a/client-js/app/elements/labrad-setting.html
+++ b/client-js/app/elements/labrad-setting.html
@@ -24,18 +24,3 @@
     </div>
   </template>
 </dom-module>
-
-
-<script>
-(function () {
-  Polymer({
-    is: 'labrad-setting',
-    properties: {
-      info: {
-        type: Object,
-        notify: true
-      }
-    }
-  });
-})();
-</script>

--- a/client-js/app/elements/labrad-setting.ts
+++ b/client-js/app/elements/labrad-setting.ts
@@ -1,0 +1,5 @@
+@component('labrad-setting')
+export class LabradSetting extends polymer.Base {
+  @property({type: Object, notify: true})
+  info: Object;
+}

--- a/client-js/app/elements/selectable-table.html
+++ b/client-js/app/elements/selectable-table.html
@@ -10,13 +10,4 @@
   <template>
     <content></content>
   </template>
-  <script>
-    Polymer({
-      is: 'selectable-table',
-      extends: 'tbody',
-      behaviors: [
-        Polymer.IronSelectableBehavior
-      ]
-    });
-  </script>
 </dom-module>

--- a/client-js/app/elements/selectable-table.ts
+++ b/client-js/app/elements/selectable-table.ts
@@ -1,0 +1,4 @@
+@component('selectable-table')
+@behavior((<any>Polymer).IronSelectableBehavior)
+@extend('tbody')
+export class SelectableTable extends polymer.Base {}

--- a/client-js/app/scripts/activities.ts
+++ b/client-js/app/scripts/activities.ts
@@ -13,6 +13,7 @@ import {LabradManager} from "../elements/labrad-manager";
 import {LabradNodes} from "../elements/labrad-nodes";
 import {LabradRegistry} from "../elements/labrad-registry";
 import {LabradServer} from "../elements/labrad-server";
+import {LabradSetting} from "../elements/labrad-setting";
 import {Plot} from "../elements/labrad-plot";
 
 export class RegistryActivity implements Activity {

--- a/client-js/app/scripts/app.ts
+++ b/client-js/app/scripts/app.ts
@@ -21,7 +21,9 @@ import {LabradManager} from "../elements/labrad-manager";
 import {LabradNodes, LabradInstanceController, LabradNodeController} from "../elements/labrad-nodes";
 import {LabradRegistry} from "../elements/labrad-registry";
 import {LabradServer} from "../elements/labrad-server";
+import {LabradSetting} from "../elements/labrad-setting";
 import {Plot} from "../elements/labrad-plot";
+import {SelectableTable} from "../elements/selectable-table";
 
 
 /**
@@ -91,7 +93,9 @@ window.addEventListener('WebComponentsReady', () => {
   LabradInstanceController.register();
   LabradNodeController.register();
   LabradServer.register();
+  LabradSetting.register();
   Plot.register();
+  SelectableTable.register();
   LabeledPlot.register();
 
   var prefix = "";

--- a/client-js/app/scripts/app.ts
+++ b/client-js/app/scripts/app.ts
@@ -15,6 +15,7 @@ import {obligate} from "./obligation";
 
 import {AppLink} from "../elements/app-link";
 import {LabradApp} from "../elements/labrad-app";
+import {LabradBreadcrumbs} from "../elements/labrad-breadcrumbs";
 import {LabradGrapher} from "../elements/labrad-grapher";
 import {LabradGrapherLive, LabeledPlot} from "../elements/labrad-grapher-live";
 import {LabradManager} from "../elements/labrad-manager";
@@ -85,6 +86,7 @@ window.addEventListener('WebComponentsReady', () => {
   // register our custom elements with polymer
   AppLink.register();
   LabradApp.register();
+  LabradBreadcrumbs.register();
   LabradGrapher.register();
   LabradGrapherLive.register();
   LabradManager.register();
@@ -92,11 +94,11 @@ window.addEventListener('WebComponentsReady', () => {
   LabradNodes.register();
   LabradInstanceController.register();
   LabradNodeController.register();
+  LabeledPlot.register();
   LabradServer.register();
   LabradSetting.register();
   Plot.register();
   SelectableTable.register();
-  LabeledPlot.register();
 
   var prefix = "";
   var baseElem = document.querySelector("base");


### PR DESCRIPTION
Fixes #220 by converting `labrad-setting.html`, `labrad-breadcrumbs.html` and `selectable-table.html` into components specified in separate TypeScript files rather than written in JavaScript within the HTML.
