### PR TITLE
Allow Scalabrad-web to load in Firefox

### DIFF
--- a/client-js/app/bundle.html
+++ b/client-js/app/bundle.html
@@ -1,0 +1,2 @@
+<link rel="import" href="/elements/elements.html">
+<script src="/scripts/bundle.js"></script>

--- a/client-js/app/index.html
+++ b/client-js/app/index.html
@@ -46,6 +46,7 @@
 </head>
 
 <body unresolved class="fullbleed layout vertical">
+  <span id="browser-sync-binding"></span>
   <script src="scripts/bundle.js"></script>
 </body>
 </html>

--- a/client-js/app/index.html
+++ b/client-js/app/index.html
@@ -43,10 +43,11 @@
        websocket api connections should be made. Comments are stripped
        when we built the dist version, so this has no effect in prod. -->
   <!-- DEV_MODE_CONFIG -->
+
+  <link rel="import" href="/bundle.html">
 </head>
 
 <body unresolved class="fullbleed layout vertical">
   <span id="browser-sync-binding"></span>
-  <script src="scripts/bundle.js"></script>
 </body>
 </html>

--- a/client-js/gulpfile.js
+++ b/client-js/gulpfile.js
@@ -29,7 +29,7 @@ var minimist = require('minimist');
 
 var knownOptions = {
   string: 'api-host',
-  default: { 
+  default: {
     'api-host': 'localhost:7667'
   }
 };
@@ -299,6 +299,12 @@ gulp.task('serve', ['bundle', 'insert-dev-config', 'styles', 'elements', 'images
   browserSync({
     notify: false,
     open: false,
+    snippetOptions: {
+      rule: {
+        match: '<span id="browser-sync-binding"></span>',
+        fn: function (snippet) { return snippet; }
+      }
+    },
     server: {
       baseDir: ['.tmp', 'app'],
       routes: {


### PR DESCRIPTION
Fixes #93, somewhat.

Firefox blacklists my GPU/Graphics Drivers on my dev machine, so WebGL doesn't work, breaking the Grapher, this isn't an issue with the build though.

The remaining functionality appears to work, though there are some styling issues in places.
