### PR TITLE
Refresh connection info periodically to keep counts updated.

### DIFF
--- a/client-js/app/elements/labrad-manager.ts
+++ b/client-js/app/elements/labrad-manager.ts
@@ -5,8 +5,8 @@ import {Places} from "../scripts/places";
 @component('labrad-manager')
 export class LabradManager extends polymer.Base {
 
-  @property({type: Array, notify: true})
-  connections: Array<ConnectionInfo>;
+  @property({type: Array, notify: true, value: () => { return []; }})
+  connections: ConnectionInfo[];
 
   @property({type: Object, notify: true})
   selectedConnection: {connId: number, name: string};
@@ -45,13 +45,17 @@ export class LabradManager extends polymer.Base {
     this.updateConnections();
   }
 
-  private async updateConnections(): Promise<void> {
-    const connections = await this.mgr.connections();
+  setConnections(connections: ConnectionInfo[]) {
     for (let c of connections) {
       if (c.server) {
         c.url = this.places.serverUrl(c.name);
       }
     }
     this.splice('connections', 0, this.connections.length, ...connections);
+  }
+
+  private async updateConnections(): Promise<void> {
+    const connections = await this.mgr.connections();
+    this.setConnections(connections);
   }
 }

--- a/client-js/app/elements/labrad-manager.ts
+++ b/client-js/app/elements/labrad-manager.ts
@@ -1,5 +1,6 @@
 import {Lifetime} from '../scripts/lifetime';
 import {ConnectionInfo, ManagerApi} from '../scripts/manager';
+import {Places} from "../scripts/places";
 
 @component('labrad-manager')
 export class LabradManager extends polymer.Base {
@@ -11,6 +12,7 @@ export class LabradManager extends polymer.Base {
   selectedConnection: {connId: number, name: string};
 
   mgr: ManagerApi;
+  places: Places;
 
   private lifetime: Lifetime = new Lifetime();
 
@@ -45,9 +47,11 @@ export class LabradManager extends polymer.Base {
 
   private async updateConnections(): Promise<void> {
     const connections = await this.mgr.connections();
-    this.splice('connections', 0, this.connections.length);
     for (let c of connections) {
-      this.push('connections', c);
+      if (c.server) {
+        c.url = this.places.serverUrl(c.name);
+      }
     }
+    this.splice('connections', 0, this.connections.length, ...connections);
   }
 }

--- a/client-js/app/scripts/activities.ts
+++ b/client-js/app/scripts/activities.ts
@@ -371,15 +371,10 @@ export class ManagerActivity implements Activity {
 
   async start(): Promise<ActivityState> {
     var connections = await this.api.connections();
-    for (let c of connections) {
-      if (c.server) {
-        c.url = this.places.serverUrl(c.name);
-      }
-    }
     var elem = <LabradManager> LabradManager.create();
-    elem.connections = connections;
     elem.mgr = this.api;
     elem.places = this.places;
+    elem.setConnections(connections);
     return {
       elem: elem,
       route: 'manager'

--- a/client-js/app/scripts/activities.ts
+++ b/client-js/app/scripts/activities.ts
@@ -370,17 +370,16 @@ export class ManagerActivity implements Activity {
               private api: manager.ManagerApi) {}
 
   async start(): Promise<ActivityState> {
-    var conns = await this.api.connections();
-    var connsWithUrl = conns.map((c) => {
-      var x = <any> c;
+    var connections = await this.api.connections();
+    for (let c of connections) {
       if (c.server) {
-        x['url'] = this.places.serverUrl(c.name);
+        c.url = this.places.serverUrl(c.name);
       }
-      return x;
-    });
+    }
     var elem = <LabradManager> LabradManager.create();
-    elem.connections = connsWithUrl;
+    elem.connections = connections;
     elem.mgr = this.api;
+    elem.places = this.places;
     return {
       elem: elem,
       route: 'manager'

--- a/client-js/app/scripts/manager.ts
+++ b/client-js/app/scripts/manager.ts
@@ -12,7 +12,7 @@ export interface ConnectionInfo {
   clientRespCount: number;
   msgSendCount: number;
   msgRecvCount: number;
-  url?: boolean;
+  url?: string;
 }
 
 export interface SettingInfo {


### PR DESCRIPTION
For now, just polls every 2 seconds and right after triggering a connection close. Would be nice to just stream the data, but that requires changes to the manager itself, so not worrying about that now.
