### PR TITLE
[#143, Part 1] Add buttons to assign servers to a node autostart list, and autostart all servers on a node.

### DIFF
--- a/client-js/app/elements/elements.html
+++ b/client-js/app/elements/elements.html
@@ -5,7 +5,6 @@
 <link rel="import" href="../bower_components/iron-form/iron-form.html">
 <link rel="import" href="../bower_components/iron-icons/editor-icons.html">
 <link rel="import" href="../bower_components/iron-icons/hardware-icons.html">
-<link rel="import" href="../bower_components/iron-icons/maps-icons.html">
 <link rel="import" href="../bower_components/iron-icons/communication-icons.html">
 <link rel="import" href="../bower_components/iron-icons/iron-icons.html">
 <link rel="import" href="../bower_components/iron-input/iron-input.html">

--- a/client-js/app/elements/elements.html
+++ b/client-js/app/elements/elements.html
@@ -5,6 +5,7 @@
 <link rel="import" href="../bower_components/iron-form/iron-form.html">
 <link rel="import" href="../bower_components/iron-icons/editor-icons.html">
 <link rel="import" href="../bower_components/iron-icons/hardware-icons.html">
+<link rel="import" href="../bower_components/iron-icons/maps-icons.html">
 <link rel="import" href="../bower_components/iron-icons/communication-icons.html">
 <link rel="import" href="../bower_components/iron-icons/iron-icons.html">
 <link rel="import" href="../bower_components/iron-input/iron-input.html">

--- a/client-js/app/elements/labrad-nodes.html
+++ b/client-js/app/elements/labrad-nodes.html
@@ -72,6 +72,12 @@
       height: 18px;
       top: 5px;
     }
+    paper-icon-button.autostart {
+      color: #75787B;
+    }
+    paper-icon-button.autostartOn {
+      color: #0F9D58;
+    }
   </style>
   <template>
     <div>
@@ -88,9 +94,7 @@
         <paper-icon-button id="start" icon="av:play-arrow"></paper-icon-button>
         <paper-icon-button id="stop" icon="av:stop"></paper-icon-button>
         <paper-icon-button id="restart" icon="av:replay"></paper-icon-button>
-        <template is="dom-if" if="{{autostart}}">
-          <paper-icon-button class$="{{autostartClass}}" id="autostart" icon="maps:directions-car"></paper-icon-button>
-        </template>
+        <paper-icon-button class$="autostart {{autostartClass}}" id="autostart" icon="maps:directions-car"></paper-icon-button>
       </span>
     </div>
   </template>

--- a/client-js/app/elements/labrad-nodes.html
+++ b/client-js/app/elements/labrad-nodes.html
@@ -38,7 +38,7 @@
     <template is="dom-if" if="{{error}}">
       <td colspan="999">
         {{error}}
-        <paper-button class='dismiss' on-click="dismissException">Dismiss</paper-button>
+        <paper-button class="dismiss" on-click="dismissException">Dismiss</paper-button>
 
         <div class="exceptionCollapse">
           <div>
@@ -46,7 +46,7 @@
             <paper-button on-click="toggleException">Show/Hide</paper-button>
           </div>
           <iron-collapse id="exceptionCollapse">
-            <div class='exception'>{{exception}}</div>
+            <div class="exception">{{exception}}</div>
           </iron-collapse>
         </div>
       </td>
@@ -146,7 +146,15 @@
 <dom-module id="labrad-nodes">
   <style>
     :host {
-      display: block;
+      height: 100%;
+      overflow: hidden;
+      display: flex;
+    }
+    #container {
+      width: 100%;
+    }
+    #left-column {
+      border-right: 1px solid #AAA;
     }
     table {
       border-collapse: collapse;
@@ -180,23 +188,62 @@
     td.controls {
       width: 350px;
     }
+    #buttons {
+      height: 50px;
+    }
+    #buttons paper-icon-button {
+      margin: 5px;
+    }
+    .autostartFilterOn {
+      color: #000;
+    }
+    .autostartFilterOff {
+      color: #aaa;
+    }
   </style>
   <template>
-    <div>
+   <div id="container">
+   <paper-header-panel id="left-column">
+    <div class="paper-header" id="buttons">
+      <paper-icon-button
+        hidden$={{isAutostartFiltered}}
+        class="autostartFilterOff"
+        icon="stars"
+        id="star"
+        on-click="toggleAutostartFilter"
+        title="Show Only Autostart Servers"></paper-icon-button>
+      <paper-icon-button
+        hidden$={{!isAutostartFiltered}}
+        class="autostartFilterOn"
+        icon="stars"
+        id="star"
+        on-click="toggleAutostartFilter"
+        title="Show All Servers"></paper-icon-button>
+    </div>
+
+    <div class="fit">
       <table>
         <thead>
           <th>Global Servers</th>
           <th></th>
-          <template is="dom-repeat" items="{{nodeNames}}" as="node">
+          <template is="dom-repeat"
+                    items="{{nodeNames}}"
+                    as="node"
+                    sort="sortNodes">
             <th><labrad-node-controller places={{places}} api={{api}} name={{node}}></labrad-node-controller></th>
           </template>
         </thead>
         <tbody>
-          <template is="dom-repeat" items="{{globalServers}}" as="server">
+          <template is="dom-repeat"
+                    items="{{globalServersFiltered}}"
+                    as="server">
             <tr>
               <td class='name'>{{server.name}}</td>
               <td class='version'>{{server.version}}</td>
-              <template is="dom-repeat" items="{{server.nodes}}" as="node">
+              <template is="dom-repeat"
+                        items="{{server.nodes}}"
+                        as="node"
+                        sort="sortNodes">
                 <td class='controls'>
                   <template is="dom-if" if="{{node.exists}}">
                     <labrad-instance-controller
@@ -227,12 +274,12 @@
           </template>
         </thead>
         <tbody>
-          <template is="dom-repeat" items="{{localServers}}" as="server">
+          <template is="dom-repeat" items="{{localServersFiltered}}" as="server">
             <tr>
-              <td class='name'>{{server.name}}</td>
-              <td class='version'>{{server.version}}</td>
+              <td class="name">{{server.name}}</td>
+              <td class="version">{{server.version}}</td>
               <template is="dom-repeat" items="{{server.nodes}}" as="node">
-                <td class='controls'>
+                <td class="controls">
                   <template is="dom-if" if="{{node.exists}}">
                     <labrad-instance-controller
                       places={{places}}
@@ -241,7 +288,8 @@
                       server={{server}}
                       instance-name={{node.instanceName}}
                       node={{node.name}}
-                      status={{node.status}} />
+                      status={{node.status}}
+                      autostart={{node.autostart}} />
                   </template>
                 </td>
               </template>
@@ -253,5 +301,7 @@
         </tbody>
       </table>
     </div>
+   </paper-header-panel>
+   </div>
   </template>
 </dom-module>

--- a/client-js/app/elements/labrad-nodes.html
+++ b/client-js/app/elements/labrad-nodes.html
@@ -94,7 +94,18 @@
         <paper-icon-button id="start" icon="av:play-arrow"></paper-icon-button>
         <paper-icon-button id="stop" icon="av:stop"></paper-icon-button>
         <paper-icon-button id="restart" icon="av:replay"></paper-icon-button>
-        <paper-icon-button class$="autostart {{autostartClass}}" id="autostart" icon="maps:directions-car"></paper-icon-button>
+        <paper-icon-button
+            hidden$="{{!autostart}}"
+            class="autostart autostartOn"
+            id="autostart"
+            icon="stars"
+            title="Autostart: On"></paper-icon-button>
+        <paper-icon-button
+            hidden$="{{autostart}}"
+            class="autostart"
+            id="autostart"
+            icon="stars"
+            title="Autostart: Off"></paper-icon-button>
       </span>
     </div>
   </template>
@@ -122,7 +133,10 @@
 
     <span hidden$="{{active}}">
       <paper-icon-button id="refresh" icon="av:replay"></paper-icon-button>
-      <paper-icon-button id="autostart" icon="maps:directions-car"></paper-icon-button>
+      <paper-icon-button
+        id="autostart"
+        icon="stars"
+        title="Start All Autostart Servers"></paper-icon-button>
     </span>
   </template>
 </dom-module>

--- a/client-js/app/elements/labrad-nodes.html
+++ b/client-js/app/elements/labrad-nodes.html
@@ -88,6 +88,9 @@
         <paper-icon-button id="start" icon="av:play-arrow"></paper-icon-button>
         <paper-icon-button id="stop" icon="av:stop"></paper-icon-button>
         <paper-icon-button id="restart" icon="av:replay"></paper-icon-button>
+        <template is="dom-if" if="{{autostart}}">
+          <paper-icon-button class$="{{autostartClass}}" id="autostart" icon="maps:directions-car"></paper-icon-button>
+        </template>
       </span>
     </div>
   </template>
@@ -115,6 +118,7 @@
 
     <span hidden$="{{active}}">
       <paper-icon-button id="refresh" icon="av:replay"></paper-icon-button>
+      <paper-icon-button id="autostart" icon="maps:directions-car"></paper-icon-button>
     </span>
   </template>
 </dom-module>
@@ -183,7 +187,8 @@
                       server={{server}}
                       instance-name={{node.instanceName}}
                       node={{node.name}}
-                      status={{node.status}} />
+                      status={{node.status}}
+                      autostart={{node.autostart}} />
                   </template>
                 </td>
               </template>

--- a/client-js/app/elements/labrad-nodes.html
+++ b/client-js/app/elements/labrad-nodes.html
@@ -99,12 +99,14 @@
             class="autostart autostartOn"
             id="autostart"
             icon="stars"
+            on-click="doAutostart"
             title="Autostart: On"></paper-icon-button>
         <paper-icon-button
             hidden$="{{autostart}}"
             class="autostart"
             id="autostart"
             icon="stars"
+            on-click="doAutostart"
             title="Autostart: Off"></paper-icon-button>
       </span>
     </div>

--- a/client-js/app/elements/labrad-nodes.html
+++ b/client-js/app/elements/labrad-nodes.html
@@ -99,14 +99,14 @@
             class="autostart autostartOn"
             id="autostart"
             icon="stars"
-            on-click="doAutostart"
+            on-click="toggleAutostart"
             title="Autostart: On"></paper-icon-button>
         <paper-icon-button
             hidden$="{{autostart}}"
             class="autostart"
             id="autostart"
             icon="stars"
-            on-click="doAutostart"
+            on-click="toggleAutostart"
             title="Autostart: Off"></paper-icon-button>
       </span>
     </div>

--- a/client-js/app/elements/labrad-nodes.html
+++ b/client-js/app/elements/labrad-nodes.html
@@ -137,7 +137,7 @@
       <paper-icon-button id="refresh" icon="av:replay"></paper-icon-button>
       <paper-icon-button
         id="autostart"
-        icon="stars"
+        icon="av:playlist-play"
         title="Start All Autostart Servers"></paper-icon-button>
     </span>
   </template>

--- a/client-js/app/elements/labrad-nodes.ts
+++ b/client-js/app/elements/labrad-nodes.ts
@@ -121,7 +121,6 @@ export class LabradInstanceController extends polymer.Base {
   }
 
 
-  @listen('autostart.click')
   async doAutostart() {
     console.info(`Autostart: server='${this.name}', node='${this.node}'`);
     try {
@@ -306,7 +305,6 @@ export class LabradNodes extends polymer.Base {
     } else {
       this.splice('info', idx, 1, msg);
     }
-    this.kick++;
   }
 
   onServerDisconnected(msg: ServerDisconnectMessage): void {

--- a/client-js/app/elements/labrad-nodes.ts
+++ b/client-js/app/elements/labrad-nodes.ts
@@ -121,7 +121,7 @@ export class LabradInstanceController extends polymer.Base {
   }
 
 
-  async doAutostart() {
+  async toggleAutostart() {
     console.info(`Autostart: server='${this.name}', node='${this.node}'`);
     try {
       if (this.autostart) {

--- a/client-js/app/elements/labrad-nodes.ts
+++ b/client-js/app/elements/labrad-nodes.ts
@@ -59,11 +59,6 @@ export class LabradInstanceController extends polymer.Base {
   places: Places;
 
   @computed()
-  autostartClass(autostart: boolean): String {
-    return (autostart) ? "autostartOn" : "";
-  }
-
-  @computed()
   serverUrl(instanceName: string, places: Places): string {
     return places.serverUrl(instanceName);
   }

--- a/client-js/app/elements/labrad-nodes.ts
+++ b/client-js/app/elements/labrad-nodes.ts
@@ -52,14 +52,16 @@ export class LabradInstanceController extends polymer.Base {
   @property({type: Boolean})
   autostart: boolean;
 
-  @property({type: String})
-  autostartClass: string;
-
   @property()
   api: NodeApi;
 
   @property()
   places: Places;
+
+  @computed()
+  autostartClass(autostart: boolean): String {
+    return (autostart) ? "autostartOn" : "";
+  }
 
   @computed()
   serverUrl(instanceName: string, places: Places): string {

--- a/client-js/app/scripts/activities.ts
+++ b/client-js/app/scripts/activities.ts
@@ -413,6 +413,10 @@ export class NodesActivity implements Activity {
 
   async start(): Promise<ActivityState> {
     var nodesInfo = await this.nodeApi.allNodes();
+    for (const node of nodesInfo) {
+      var list = await this.nodeApi.autostartList(node.name);
+      node.autostartList = list;
+    }
     var elem = <LabradNodes> LabradNodes.create();
     elem.info = nodesInfo;
     elem.places = this.places;

--- a/client-js/app/scripts/activities.ts
+++ b/client-js/app/scripts/activities.ts
@@ -412,13 +412,15 @@ export class NodesActivity implements Activity {
               private nodeApi: node.NodeApi) {}
 
   async start(): Promise<ActivityState> {
+    var elem = <LabradNodes> LabradNodes.create();
+
     var nodesInfo = await this.nodeApi.allNodes();
     for (const node of nodesInfo) {
       var list = await this.nodeApi.autostartList(node.name);
       node.autostartList = list;
+      elem.addItemToList(node);
     }
-    var elem = <LabradNodes> LabradNodes.create();
-    elem.info = nodesInfo;
+
     elem.places = this.places;
     elem.api = this.nodeApi;
     elem.managerApi = this.mgrApi;

--- a/client-js/app/scripts/node.ts
+++ b/client-js/app/scripts/node.ts
@@ -6,13 +6,15 @@ export interface ServerStatus {
   description: string;
   version: string;
   instanceName: string;
-  environmentVars: Array<string>;
-  instances: Array<string>;
+  environmentVars: string[];
+  instances: string[];
+  autostart: boolean;
 }
 
 export interface NodeStatus {
   name: string;
-  servers: Array<ServerStatus>;
+  servers: ServerStatus[];
+  autostartList: string[];
 }
 
 export interface ServerStatusMessage {
@@ -26,6 +28,11 @@ export interface NodeApi {
   allNodes(): Promise<Array<NodeStatus>>;
 
   refreshNode(node: string): Promise<string>;
+
+  autostartNode(node: string): Promise<string>;
+  autostartList(node: string): Promise<string[]>;
+  autostartAdd(node: string): Promise<string>;
+  autostartRemove(node: string): Promise<string>;
 
   restartServer(params: {node: string; server: string}): Promise<void>;
   startServer(params: {node: string; server: string}): Promise<void>;
@@ -52,6 +59,22 @@ export class NodeService extends rpc.RpcService implements NodeApi {
 
   refreshNode(node: string): Promise<string> {
     return this.call<string>('refreshNode', [node]);
+  }
+
+  autostartNode(node: string): Promise<string> {
+    return this.call<string>('autostartNode', [node]);
+  }
+
+  autostartList(node: string): Promise<string[]> {
+    return this.call<string[]>('autostartList', [node]);
+  }
+
+  autostartAdd(node: string): Promise<string> {
+    return this.call<string>('autostartAdd', [node]);
+  }
+
+  autostartRemove(node: string): Promise<string> {
+    return this.call<string>('autostartRemove', [node]);
   }
 
   restartServer(params: {node: string; server: string}): Promise<void> {

--- a/client-js/app/scripts/node.ts
+++ b/client-js/app/scripts/node.ts
@@ -31,8 +31,8 @@ export interface NodeApi {
 
   autostartNode(node: string): Promise<string>;
   autostartList(node: string): Promise<string[]>;
-  autostartAdd(node: string): Promise<string>;
-  autostartRemove(node: string): Promise<string>;
+  autostartAdd(params: {node: string; server: string}): Promise<void>;
+  autostartRemove(params: {node: string; server: string}): Promise<void>;
 
   restartServer(params: {node: string; server: string}): Promise<void>;
   startServer(params: {node: string; server: string}): Promise<void>;
@@ -69,12 +69,12 @@ export class NodeService extends rpc.RpcService implements NodeApi {
     return this.call<string[]>('autostartList', [node]);
   }
 
-  autostartAdd(node: string): Promise<string> {
-    return this.call<string>('autostartAdd', [node]);
+  autostartAdd(params: {node: string; server: string}): Promise<void> {
+    return this.call<void>('autostartAdd', params);
   }
 
-  autostartRemove(node: string): Promise<string> {
-    return this.call<string>('autostartRemove', [node]);
+  autostartRemove(params: {node: string; server: string}): Promise<void> {
+    return this.call<void>('autostartRemove', params);
   }
 
   restartServer(params: {node: string; server: string}): Promise<void> {

--- a/server/src/main/scala/org/labrad/browser/ApiBackend.scala
+++ b/server/src/main/scala/org/labrad/browser/ApiBackend.scala
@@ -76,6 +76,10 @@ class ApiBackend(config: LabradConnectionConfig)(implicit ec: ExecutionContext) 
 
       CALL  org.labrad.node.allNodes       nodeApi.allNodes
       CALL                 .refreshNode           .refreshNode
+      CALL                 .autostartNode         .autostartNode
+      CALL                 .autostartList         .autostartList
+      CALL                 .autostartAdd          .autostartAdd
+      CALL                 .autostartRemove       .autostartRemove
       CALL                 .restartServer         .restartServer
       CALL                 .startServer           .startServer
       CALL                 .stopServer            .stopServer

--- a/server/src/main/scala/org/labrad/browser/NodeApi.scala
+++ b/server/src/main/scala/org/labrad/browser/NodeApi.scala
@@ -64,15 +64,11 @@ class NodeApi(cxn: LabradConnection)(implicit ec: ExecutionContext) extends Logg
   }
 
   def autostartAdd(node: String, server: String): Future[Unit] = {
-    async {
-      cxn.to(node).call("autostart_add", Str(server))
-    }
+    cxn.to(node).call("autostart_add", Str(server)).map { _ => () }
   }
 
   def autostartRemove(node: String, server: String): Future[Unit] = {
-    async {
-      cxn.to(node).call("autostart_remove", Str(server))
-    }
+    cxn.to(node).call("autostart_remove", Str(server)).map { _ => () }
   }
 
   def restartServer(node: String, server: String) = doRequest(node, server, "restart")

--- a/server/src/main/scala/org/labrad/browser/NodeApi.scala
+++ b/server/src/main/scala/org/labrad/browser/NodeApi.scala
@@ -63,12 +63,12 @@ class NodeApi(cxn: LabradConnection)(implicit ec: ExecutionContext) extends Logg
     }
   }
 
-  def autostartAdd(node: String): Future[String] = {
-    cxn.to(node).call("autostart_add")
+  def autostartAdd(node: String, server: String): Unit = {
+    cxn.to(node).call("autostart_add", Str(server))
   }
 
-  def autostartRemove(node: String): Future[String] = {
-    cxn.to(node).call("autostart_remove")
+  def autostartRemove(node: String, server: String): Unit = {
+    cxn.to(node).call("autostart_remove", Str(server))
   }
 
   def restartServer(node: String, server: String) = doRequest(node, server, "restart")

--- a/server/src/main/scala/org/labrad/browser/NodeApi.scala
+++ b/server/src/main/scala/org/labrad/browser/NodeApi.scala
@@ -63,12 +63,16 @@ class NodeApi(cxn: LabradConnection)(implicit ec: ExecutionContext) extends Logg
     }
   }
 
-  def autostartAdd(node: String, server: String): Unit = {
-    cxn.to(node).call("autostart_add", Str(server))
+  def autostartAdd(node: String, server: String): Future[Unit] = {
+    async {
+      cxn.to(node).call("autostart_add", Str(server))
+    }
   }
 
-  def autostartRemove(node: String, server: String): Unit = {
-    cxn.to(node).call("autostart_remove", Str(server))
+  def autostartRemove(node: String, server: String): Future[Unit] = {
+    async {
+      cxn.to(node).call("autostart_remove", Str(server))
+    }
   }
 
   def restartServer(node: String, server: String) = doRequest(node, server, "restart")

--- a/server/src/main/scala/org/labrad/browser/NodeApi.scala
+++ b/server/src/main/scala/org/labrad/browser/NodeApi.scala
@@ -50,6 +50,27 @@ class NodeApi(cxn: LabradConnection)(implicit ec: ExecutionContext) extends Logg
     }
   }
 
+  def autostartNode(node: String): Future[String] = {
+    cxn.to(node).call("autostart").map { _ =>
+      "autostarted"
+    }
+  }
+
+  def autostartList(node: String): Future[Seq[String]] = {
+    async {
+      val list = await { cxn.to(node).call("autostart_list") }
+      list.get[Seq[String]]
+    }
+  }
+
+  def autostartAdd(node: String): Future[String] = {
+    cxn.to(node).call("autostart_add")
+  }
+
+  def autostartRemove(node: String): Future[String] = {
+    cxn.to(node).call("autostart_remove")
+  }
+
   def restartServer(node: String, server: String) = doRequest(node, server, "restart")
   def startServer(node: String, server: String) = doRequest(node, server, "start")
   def stopServer(node: String, server: String) = doRequest(node, server, "stop")


### PR DESCRIPTION
Partial fix for #143. Added buttons to each server in the Node manager allowing the adding/removing of each server from the respective node's autostart list. Additionally added a button at the top of each node that will start all nodes on the autostart list.
