### PR TITLE
[#143, Part 2] Added filtering of servers in Node view based on autostart status.

### DIFF
--- a/client-js/app/elements/labrad-nodes.html
+++ b/client-js/app/elements/labrad-nodes.html
@@ -282,7 +282,8 @@
                       server={{server}}
                       instance-name={{node.instanceName}}
                       node={{node.name}}
-                      status={{node.status}} />
+                      status={{node.status}}
+                      autostart={{node.autostart}} />
                   </template>
                 </td>
               </template>

--- a/client-js/app/elements/labrad-nodes.html
+++ b/client-js/app/elements/labrad-nodes.html
@@ -226,17 +226,25 @@
         <thead>
           <th>Global Servers</th>
           <th></th>
-          <template is="dom-repeat" items="{{nodeNames}}" as="node">
+          <template is="dom-repeat"
+                    items="{{nodeNames}}"
+                    as="node"
+                    sort="sortNodes">
             <th><labrad-node-controller places={{places}} api={{api}} name={{node}}></labrad-node-controller></th>
           </template>
         </thead>
         <tbody>
-          <template is="dom-repeat" items="{{globalServersFiltered}}" as="server">
+          <template is="dom-repeat"
+                    items="{{globalServersFiltered}}"
+                    as="server">
             <tr>
-              <td class="name">{{server.name}}</td>
-              <td class="version">{{server.version}}</td>
-              <template is="dom-repeat" items="{{server.nodes}}" as="node">
-                <td class="controls">
+              <td class='name'>{{server.name}}</td>
+              <td class='version'>{{server.version}}</td>
+              <template is="dom-repeat"
+                        items="{{server.nodes}}"
+                        as="node"
+                        sort="sortNodes">
+                <td class='controls'>
                   <template is="dom-if" if="{{node.exists}}">
                     <labrad-instance-controller
                       places={{places}}

--- a/client-js/app/elements/labrad-nodes.html
+++ b/client-js/app/elements/labrad-nodes.html
@@ -146,16 +146,14 @@
 <dom-module id="labrad-nodes">
   <style>
     :host {
-      display: block;
+      height: 100%;
+      overflow: hidden;
+      display: flex;
     }
     #container {
-      display: flex;
-      flex-grow: 1;
+      width: 100%;
     }
     #left-column {
-      flex-basis: 100%;
-      flex-direction: column;
-      flex-grow: 1;
       border-right: 1px solid #AAA;
     }
     table {
@@ -204,7 +202,7 @@
     }
   </style>
   <template>
-   <div id="container" class="fit">
+   <div id="container">
    <paper-header-panel id="left-column">
     <div class="paper-header" id="buttons">
       <paper-icon-button

--- a/client-js/app/elements/labrad-nodes.html
+++ b/client-js/app/elements/labrad-nodes.html
@@ -146,6 +146,16 @@
     :host {
       display: block;
     }
+    #container {
+      display: flex;
+      flex-grow: 1;
+    }
+    #left-column {
+      flex-basis: 100%;
+      flex-direction: column;
+      flex-grow: 1;
+      border-right: 1px solid #AAA;
+    }
     table {
       border-collapse: collapse;
       width: 100%;
@@ -178,9 +188,40 @@
     td.controls {
       width: 350px;
     }
+    #buttons {
+      height: 50px;
+    }
+    #buttons paper-icon-button {
+      margin: 5px;
+    }
+    .autostartFilterOn {
+      color: #000;
+    }
+    .autostartFilterOff {
+      color: #aaa;
+    }
   </style>
   <template>
-    <div>
+   <div id="container" class='fit'>
+   <paper-header-panel id="left-column">
+    <div class="paper-header" id="buttons">
+      <paper-icon-button
+        hidden$={{isAutostartFiltered}}
+        class='autostartFilterOff'
+        icon="stars"
+        id="star"
+        on-click="autostartFilter"
+        title="Show Only Autostart Servers"></paper-icon-button>
+      <paper-icon-button
+        hidden$={{!isAutostartFiltered}}
+        class='autostartFilterOn'
+        icon="stars"
+        id="star"
+        on-click="autostartFilter"
+        title="Show All Servers"></paper-icon-button>
+    </div>
+
+    <div class='fit'>
       <table>
         <thead>
           <th>Global Servers</th>
@@ -251,5 +292,7 @@
         </tbody>
       </table>
     </div>
+   </paper-header-panel>
+   </div>
   </template>
 </dom-module>

--- a/client-js/app/elements/labrad-nodes.html
+++ b/client-js/app/elements/labrad-nodes.html
@@ -212,14 +212,14 @@
         class="autostartFilterOff"
         icon="stars"
         id="star"
-        on-click="autostartFilter"
+        on-click="toggleAutostartFilter"
         title="Show Only Autostart Servers"></paper-icon-button>
       <paper-icon-button
         hidden$={{!isAutostartFiltered}}
         class="autostartFilterOn"
         icon="stars"
         id="star"
-        on-click="autostartFilter"
+        on-click="toggleAutostartFilter"
         title="Show All Servers"></paper-icon-button>
     </div>
 

--- a/client-js/app/elements/labrad-nodes.html
+++ b/client-js/app/elements/labrad-nodes.html
@@ -38,7 +38,7 @@
     <template is="dom-if" if="{{error}}">
       <td colspan="999">
         {{error}}
-        <paper-button class='dismiss' on-click="dismissException">Dismiss</paper-button>
+        <paper-button class="dismiss" on-click="dismissException">Dismiss</paper-button>
 
         <div class="exceptionCollapse">
           <div>
@@ -46,7 +46,7 @@
             <paper-button on-click="toggleException">Show/Hide</paper-button>
           </div>
           <iron-collapse id="exceptionCollapse">
-            <div class='exception'>{{exception}}</div>
+            <div class="exception">{{exception}}</div>
           </iron-collapse>
         </div>
       </td>
@@ -204,26 +204,26 @@
     }
   </style>
   <template>
-   <div id="container" class='fit'>
+   <div id="container" class="fit">
    <paper-header-panel id="left-column">
     <div class="paper-header" id="buttons">
       <paper-icon-button
         hidden$={{isAutostartFiltered}}
-        class='autostartFilterOff'
+        class="autostartFilterOff"
         icon="stars"
         id="star"
         on-click="autostartFilter"
         title="Show Only Autostart Servers"></paper-icon-button>
       <paper-icon-button
         hidden$={{!isAutostartFiltered}}
-        class='autostartFilterOn'
+        class="autostartFilterOn"
         icon="stars"
         id="star"
         on-click="autostartFilter"
         title="Show All Servers"></paper-icon-button>
     </div>
 
-    <div class='fit'>
+    <div class="fit">
       <table>
         <thead>
           <th>Global Servers</th>
@@ -235,10 +235,10 @@
         <tbody>
           <template is="dom-repeat" items="{{globalServersFiltered}}" as="server">
             <tr>
-              <td class='name'>{{server.name}}</td>
-              <td class='version'>{{server.version}}</td>
+              <td class="name">{{server.name}}</td>
+              <td class="version">{{server.version}}</td>
               <template is="dom-repeat" items="{{server.nodes}}" as="node">
-                <td class='controls'>
+                <td class="controls">
                   <template is="dom-if" if="{{node.exists}}">
                     <labrad-instance-controller
                       places={{places}}
@@ -270,10 +270,10 @@
         <tbody>
           <template is="dom-repeat" items="{{localServersFiltered}}" as="server">
             <tr>
-              <td class='name'>{{server.name}}</td>
-              <td class='version'>{{server.version}}</td>
+              <td class="name">{{server.name}}</td>
+              <td class="version">{{server.version}}</td>
               <template is="dom-repeat" items="{{server.nodes}}" as="node">
-                <td class='controls'>
+                <td class="controls">
                   <template is="dom-if" if="{{node.exists}}">
                     <labrad-instance-controller
                       places={{places}}

--- a/client-js/app/elements/labrad-nodes.html
+++ b/client-js/app/elements/labrad-nodes.html
@@ -233,7 +233,7 @@
           </template>
         </thead>
         <tbody>
-          <template is="dom-repeat" items="{{globalServers}}" as="server">
+          <template is="dom-repeat" items="{{globalServersFiltered}}" as="server">
             <tr>
               <td class='name'>{{server.name}}</td>
               <td class='version'>{{server.version}}</td>
@@ -268,7 +268,7 @@
           </template>
         </thead>
         <tbody>
-          <template is="dom-repeat" items="{{localServers}}" as="server">
+          <template is="dom-repeat" items="{{localServersFiltered}}" as="server">
             <tr>
               <td class='name'>{{server.name}}</td>
               <td class='version'>{{server.version}}</td>

--- a/client-js/app/elements/labrad-nodes.html
+++ b/client-js/app/elements/labrad-nodes.html
@@ -99,12 +99,14 @@
             class="autostart autostartOn"
             id="autostart"
             icon="stars"
+            on-click="doAutostart"
             title="Autostart: On"></paper-icon-button>
         <paper-icon-button
             hidden$="{{autostart}}"
             class="autostart"
             id="autostart"
             icon="stars"
+            on-click="doAutostart"
             title="Autostart: Off"></paper-icon-button>
       </span>
     </div>

--- a/client-js/app/elements/labrad-nodes.ts
+++ b/client-js/app/elements/labrad-nodes.ts
@@ -439,7 +439,7 @@ export class LabradNodes extends polymer.Base {
 
     const filterFunction = this.filterServersFunction();
 
-    const versionMap = this._versionMap(this.info);
+    const versionMap = this.versionMap(this.info);
 
     for (const server of item.servers) {
       const versions = versionMap.get(server.name);
@@ -498,7 +498,7 @@ export class LabradNodes extends polymer.Base {
   }
 
 
-  private _serverStatusMap(statuses: ServerStatus[]): Map<String, ServerStatus> {
+  private serverStatusMap(statuses: ServerStatus[]): Map<String, ServerStatus> {
     const serverStatusMap = new Map<String, ServerStatus>();
     for (const s of statuses) {
       serverStatusMap.set(s.name, s);
@@ -507,7 +507,7 @@ export class LabradNodes extends polymer.Base {
   }
 
 
-  private _nodeAutostartSet(node: NodeStatus): Set<String> {
+  private nodeAutostartSet(node: NodeStatus): Set<String> {
     const nodeAutostartSet = new Set();
     for (const server of node.autostartList) {
       nodeAutostartSet.add(server);
@@ -543,7 +543,7 @@ export class LabradNodes extends polymer.Base {
     }
 
     for (const node of this.info) {
-      const serverStatusMap = this._serverStatusMap(node.servers);
+      const serverStatusMap = this.serverStatusMap(node.servers);
 
       const nodeHasServer = serverStatusMap.has(server.name);
       const serverHasNode = serverNodes.has(node.name);
@@ -554,7 +554,7 @@ export class LabradNodes extends polymer.Base {
         // insert a noop node into the server so it is still displayed properly.
         if (nodeHasServer) {
           const serverStatus = serverStatusMap.get(server.name);
-          const nodeAutostartSet = this._nodeAutostartSet(node);
+          const nodeAutostartSet = this.nodeAutostartSet(node);
 
           this.push(`${serversName}.#${serverIdx}.nodes`, {
             name: node.name,
@@ -605,14 +605,14 @@ export class LabradNodes extends polymer.Base {
   }
 
 
-  private _nodeNames(info: Array<NodeStatus>): Array<string> {
+  private nodeNames(info: Array<NodeStatus>): Array<string> {
     var names = info.map((n) => n.name);
     names.sort();
     return names;
   }
 
 
-  private _versionMap(info: Array<NodeStatus>): Map<string, Set<string>> {
+  private versionMap(info: Array<NodeStatus>): Map<string, Set<string>> {
     var versionMap = new Map<string, Set<string>>();
     for (let nodeStatus of info) {
       for (let {name, version} of nodeStatus.servers) {
@@ -628,6 +628,6 @@ export class LabradNodes extends polymer.Base {
 
   @computed()
   nodeNames(info: Array<NodeStatus>, kick: number): Array<string> {
-    return this._nodeNames(info)
+    return this.nodeNames(info)
   }
 }

--- a/client-js/app/elements/labrad-nodes.ts
+++ b/client-js/app/elements/labrad-nodes.ts
@@ -241,10 +241,17 @@ interface ServerInfo {
   autostart: boolean;
   errorString: string;
   errorException: string;
-  nodes: Array<NodeServerStatus>;
+  nodes: NodeServerStatus[];
 }
 
-type NodeServerStatus = {name: string, exists: boolean, autostart?: boolean, status?: string, instanceName?: string};
+type NodeServerStatus = {
+  name: string,
+  exists: boolean,
+  autostart?: boolean,
+  status?: string,
+  instanceName?: string
+};
+
 type ServerFilterFunction = (item: ServerInfo) => boolean;
 
 

--- a/client-js/app/elements/labrad-nodes.ts
+++ b/client-js/app/elements/labrad-nodes.ts
@@ -170,7 +170,7 @@ export class LabradInstanceController extends polymer.Base {
    * state of this particular server instance.
    */
   updateButtonState(status: string) {
-    var options = {info: false, start: false, stop: false, restart: false};
+    const options = {info: false, start: false, stop: false, restart: false};
     switch (status) {
       case 'STOPPED': this.active = false; options.start = true; break;
       case 'STARTING': this.active = true; break;
@@ -178,8 +178,8 @@ export class LabradInstanceController extends polymer.Base {
       case 'STOPPING': this.active = true; break;
       default: break;
     }
-    var updateButton = (name: string): void => {
-      var button = this.$[name];
+    const updateButton = (name: string): void => {
+      const button = this.$[name];
       if (options[name]) {
         button.removeAttribute('disabled');
       } else {
@@ -387,8 +387,8 @@ export class LabradNodes extends polymer.Base {
 
 
   onServerStatus(msg: ServerStatusMessage): void {
-    var instances = Polymer.dom(this.root).querySelectorAll('labrad-instance-controller');
-    for (const inst of instance) {
+    const instances = Polymer.dom(this.root).querySelectorAll('labrad-instance-controller');
+    for (const inst of instances) {
       const instance = <any>inst;
       if (instance.name === msg.server) {
         // Send the server status to all instance controllers, even if they are
@@ -607,14 +607,14 @@ export class LabradNodes extends polymer.Base {
 
 
   private _nodeNames(info: Array<NodeStatus>): Array<string> {
-    var names = info.map((n) => n.name);
+    const names = info.map((n) => n.name);
     names.sort();
     return names;
   }
 
 
   private versionMap(info: Array<NodeStatus>): Map<string, Set<string>> {
-    var versionMap = new Map<string, Set<string>>();
+    const versionMap = new Map<string, Set<string>>();
     for (let nodeStatus of info) {
       for (let {name, version} of nodeStatus.servers) {
         if (!versionMap.has(name)) {

--- a/client-js/app/elements/labrad-nodes.ts
+++ b/client-js/app/elements/labrad-nodes.ts
@@ -74,7 +74,6 @@ export class LabradInstanceController extends polymer.Base {
     });
   }
 
-
   @observe('status')
   statusChanged(newStatus: string, oldStatus: string) {
     this.updateButtonState(newStatus);
@@ -285,7 +284,23 @@ export class LabradNodes extends polymer.Base {
 
   @listen('labrad-instance-controller::ready')
   onLabradInstanceControllerReady(event) {
-    this.onServerStatus(event.detail);
+    // If a new labrad-instance-controller has readied, we need to broadcast
+    // the state of each controller of that server type to all others of the
+    // same type. This informs existing servers of the new server state, and
+    // informs the new server of the existing servers' states.
+    const instances = Polymer.dom(this.root).querySelectorAll('labrad-instance-controller');
+    for (var i = 0; i < instances.length; i++) {
+      const instance = <any>instances[i];
+      if (instance.name == event.detail.server) {
+        const msg = {
+          node: instance.node,
+          server: instance.name,
+          instance: instance.instanceName,
+          status: instance.status
+        };
+        this.onServerStatus(msg);
+      }
+    }
   }
 
 

--- a/client-js/app/elements/labrad-nodes.ts
+++ b/client-js/app/elements/labrad-nodes.ts
@@ -275,16 +275,16 @@ export class LabradNodes extends polymer.Base {
   @property({type: Boolean, value: false, notify: true})
   isAutostartFiltered: boolean;
 
-  @property({type: Object, value: []})
+  @property({type: Array, value: []})
   globalServers: ServerInfo[];
 
-  @property({type: Object, value: []})
+  @property({type: Array, value: []})
   localServers: ServerInfo[];
 
-  @property({type: Object, value: []})
+  @property({type: Array, value: []})
   globalServersFiltered: ServerInfo[];
 
-  @property({type: Object, value: []})
+  @property({type: Array, value: []})
   localServersFiltered: ServerInfo[];
 
   private lifetime = new Lifetime();
@@ -321,7 +321,7 @@ export class LabradNodes extends polymer.Base {
   }
 
 
-  autostartFilter() {
+  toggleAutostartFilter() {
     this.set('isAutostartFiltered', !this.isAutostartFiltered);
     this.updateFilters();
   }
@@ -399,17 +399,25 @@ export class LabradNodes extends polymer.Base {
   }
 
 
+  /**
+   * The index of a given node within an array.
+   *
+   * Returns -1 if item is not found.
+   **/
   private getNodeIndex(item: (NodeStatus | ServerDisconnectMessage), array: NodeStatus[]): number {
-    let idx = -1;
     for (let i = 0; i < array.length; ++i) {
       if (array[i].name === item.name) {
-        idx = i;
-        break;
+        return i;
       }
     }
-    return idx;
+    return -1;
   }
 
+  /**
+   * The index of a given server within an array.
+   *
+   * Returns -1 if item is not found.
+   **/
   private getServerIndex(server: ServerStatus, servers: ServerInfo[]): number {
     for (let idx = 0; idx < servers.length; ++idx) {
       const s = servers[idx];

--- a/client-js/app/elements/labrad-nodes.ts
+++ b/client-js/app/elements/labrad-nodes.ts
@@ -170,14 +170,33 @@ export class LabradInstanceController extends polymer.Base {
    * state of this particular server instance.
    */
   updateButtonState(status: string) {
-    const options = {info: false, start: false, stop: false, restart: false};
+    const options = {
+      info: false,
+      start: false,
+      stop: false,
+      restart: false
+    };
+
     switch (status) {
-      case 'STOPPED': this.active = false; options.start = true; break;
-      case 'STARTING': this.active = true; break;
-      case 'STARTED': this.active = false; options.info = true; options.stop = true; options.restart = true; break;
-      case 'STOPPING': this.active = true; break;
+      case 'STOPPED':
+        this.active = false;
+        options.start = true;
+        break;
+      case 'STARTING':
+        this.active = true;
+        break;
+      case 'STARTED':
+        this.active = false;
+        options.info = true;
+        options.stop = true;
+        options.restart = true;
+        break;
+      case 'STOPPING':
+        this.active = true;
+        break;
       default: break;
     }
+
     const updateButton = (name: string): void => {
       const button = this.$[name];
       if (options[name]) {
@@ -186,6 +205,7 @@ export class LabradInstanceController extends polymer.Base {
         button.setAttribute('disabled', 'disabled');
       }
     }
+
     updateButton('info');
     updateButton('start');
     updateButton('stop');
@@ -257,7 +277,7 @@ type ServerFilterFunction = (item: ServerInfo) => boolean;
 
 @component('labrad-nodes')
 export class LabradNodes extends polymer.Base {
-  @property({type: Array, notify: true, value: []})
+  @property({type: Array, notify: true, value: () => []})
   info: NodeStatus[];
 
   @property({type: Object})
@@ -275,16 +295,16 @@ export class LabradNodes extends polymer.Base {
   @property({type: Boolean, value: false, notify: true})
   isAutostartFiltered: boolean;
 
-  @property({type: Array, value: []})
+  @property({type: Array, value: () => []})
   globalServers: ServerInfo[];
 
-  @property({type: Array, value: []})
+  @property({type: Array, value: () => []})
   localServers: ServerInfo[];
 
-  @property({type: Array, value: []})
+  @property({type: Array, value: () => []})
   globalServersFiltered: ServerInfo[];
 
-  @property({type: Array, value: []})
+  @property({type: Array, value: () => []})
   localServersFiltered: ServerInfo[];
 
   private lifetime = new Lifetime();
@@ -295,7 +315,8 @@ export class LabradNodes extends polymer.Base {
     // the state of each controller of that server type to all others of the
     // same type. This informs existing servers of the new server state, and
     // informs the new server of the existing servers' states.
-    const instances = Polymer.dom(this.root).querySelectorAll('labrad-instance-controller');
+    const instances = Polymer.dom(this.root)
+                             .querySelectorAll('labrad-instance-controller');
     for (const inst of instances) {
       // Required to make the compiler cast the object correctly.
       const instance = <any>inst;
@@ -330,8 +351,10 @@ export class LabradNodes extends polymer.Base {
 
   updateFilters() {
     const filterFunction = this.filterServersFunction();
-    this.set('globalServersFiltered', this.globalServers.filter(filterFunction));
-    this.set('localServersFiltered', this.localServers.filter(filterFunction));
+    this.set('globalServersFiltered',
+             this.globalServers.filter(filterFunction));
+    this.set('localServersFiltered',
+             this.localServers.filter(filterFunction));
   }
 
 
@@ -342,8 +365,10 @@ export class LabradNodes extends polymer.Base {
   @observe('api')
   apiChanged(newApi: NodeApi, oldApi: NodeApi) {
     if (this.defined(newApi)) {
-      newApi.nodeStatus.add((msg) => this.onNodeStatus(msg), this.lifetime);
-      newApi.serverStatus.add((msg) => this.onServerStatus(msg), this.lifetime);
+      newApi.nodeStatus.add(
+        (msg) => this.onNodeStatus(msg), this.lifetime);
+      newApi.serverStatus.add(
+        (msg) => this.onServerStatus(msg), this.lifetime);
     }
   }
 
@@ -351,7 +376,8 @@ export class LabradNodes extends polymer.Base {
   @observe('managerApi')
   managerChanged(newManager: ManagerApi, oldManager: ManagerApi) {
     if (this.defined(newManager)) {
-      newManager.serverDisconnected.add((msg) => this.onServerDisconnected(msg), this.lifetime);
+      newManager.serverDisconnected.add(
+        (msg) => this.onServerDisconnected(msg), this.lifetime);
     }
   }
 
@@ -387,7 +413,8 @@ export class LabradNodes extends polymer.Base {
 
 
   onServerStatus(msg: ServerStatusMessage): void {
-    const instances = Polymer.dom(this.root).querySelectorAll('labrad-instance-controller');
+    const instances = Polymer.dom(this.root)
+                             .querySelectorAll('labrad-instance-controller');
     for (const inst of instances) {
       const instance = <any>inst;
       if (instance.name === msg.server) {
@@ -405,7 +432,8 @@ export class LabradNodes extends polymer.Base {
    *
    * Returns -1 if item is not found.
    **/
-  private getNodeIndex(item: (NodeStatus | ServerDisconnectMessage), array: NodeStatus[]): number {
+  private getNodeIndex(item: (NodeStatus | ServerDisconnectMessage),
+                       array: NodeStatus[]): number {
     for (let i = 0; i < array.length; ++i) {
       if (array[i].name === item.name) {
         return i;

--- a/client-js/app/elements/labrad-nodes.ts
+++ b/client-js/app/elements/labrad-nodes.ts
@@ -121,7 +121,6 @@ export class LabradInstanceController extends polymer.Base {
   }
 
 
-  @listen('autostart.click')
   async doAutostart() {
     console.info(`Autostart: server='${this.name}', node='${this.node}'`);
     try {
@@ -345,7 +344,6 @@ export class LabradNodes extends polymer.Base {
     } else {
       this.splice('info', idx, 1, item);
     }
-
     this.kick++;
   }
 
@@ -355,8 +353,6 @@ export class LabradNodes extends polymer.Base {
     if (idx !== -1) {
       this.splice('info', idx, 1);
     }
-
-    this.kick++;
   }
 
 

--- a/client-js/app/elements/labrad-nodes.ts
+++ b/client-js/app/elements/labrad-nodes.ts
@@ -528,6 +528,9 @@ export class LabradNodes extends polymer.Base {
     for (let nodeIdx = nodes.length - 1; nodeIdx >= 0; --nodeIdx) {
       const node = nodes[nodeIdx];
       if (!onlineNodes.has(node.name)) {
+        // The Polymer way to mutate the array that exists at
+        // `this[serversName][serverIdx].nodes`.
+        // The # is used to access a particular index in an array.
         this.splice(`${serversName}.#${serverIdx}.nodes`, nodeIdx, 1);
       }
     }

--- a/client-js/app/elements/labrad-nodes.ts
+++ b/client-js/app/elements/labrad-nodes.ts
@@ -296,8 +296,9 @@ export class LabradNodes extends polymer.Base {
     // same type. This informs existing servers of the new server state, and
     // informs the new server of the existing servers' states.
     const instances = Polymer.dom(this.root).querySelectorAll('labrad-instance-controller');
-    for (var i = 0; i < instances.length; i++) {
-      const instance = <any>instances[i];
+    for (const inst of instances) {
+      // Required to make the compiler cast the object correctly.
+      const instance = <any>inst;
       if (instance.name == event.detail.server) {
         const msg = {
           node: instance.node,
@@ -387,8 +388,8 @@ export class LabradNodes extends polymer.Base {
 
   onServerStatus(msg: ServerStatusMessage): void {
     var instances = Polymer.dom(this.root).querySelectorAll('labrad-instance-controller');
-    for (var i = 0; i < instances.length; i++) {
-      var instance = <any>instances[i];
+    for (const inst of instance) {
+      const instance = <any>inst;
       if (instance.name === msg.server) {
         // Send the server status to all instance controllers, even if they are
         // on other nodes. This is because for global servers we must lock out
@@ -605,7 +606,7 @@ export class LabradNodes extends polymer.Base {
   }
 
 
-  private nodeNames(info: Array<NodeStatus>): Array<string> {
+  private _nodeNames(info: Array<NodeStatus>): Array<string> {
     var names = info.map((n) => n.name);
     names.sort();
     return names;
@@ -628,6 +629,6 @@ export class LabradNodes extends polymer.Base {
 
   @computed()
   nodeNames(info: Array<NodeStatus>, kick: number): Array<string> {
-    return this.nodeNames(info)
+    return this._nodeNames(info)
   }
 }

--- a/client-js/app/scripts/activities.ts
+++ b/client-js/app/scripts/activities.ts
@@ -412,13 +412,15 @@ export class NodesActivity implements Activity {
               private nodeApi: node.NodeApi) {}
 
   async start(): Promise<ActivityState> {
+    var elem = <LabradNodes> LabradNodes.create();
+
     var nodesInfo = await this.nodeApi.allNodes();
     for (const node of nodesInfo) {
       var list = await this.nodeApi.autostartList(node.name);
       node.autostartList = list;
+      elem.addItemToList(node);
     }
-    var elem = <LabradNodes> LabradNodes.create();
-    elem.info = nodesInfo;
+
     elem.places = this.places;
     elem.api = this.nodeApi;
     elem.managerApi = this.mgrApi;


### PR DESCRIPTION
Partial fix for #143. Added controls for filtering the list of servers based on if they appear in an autostart list or not. 

This required refactoring the code to no longer use computed properties. Specifically, with the original way, when filtering the list, all state information of the servers would be lost as the list would just get recreated from scratch. The new code isn't substantially more complicated than the existing, despite having to properly keep the list state current.

This also fixes an unreported bug where the control states were incorrect on page load due to the server controls not communicating their state to one another.
