### PR TITLE
[#143, Part 3] Change nodeNames in labrad-nodes to be a non-computed property.

### DIFF
--- a/client-js/app/elements/labrad-nodes.html
+++ b/client-js/app/elements/labrad-nodes.html
@@ -228,16 +228,24 @@
         <thead>
           <th>Global Servers</th>
           <th></th>
-          <template is="dom-repeat" items="{{nodeNames}}" as="node">
+          <template is="dom-repeat"
+                    items="{{nodeNames}}"
+                    as="node"
+                    sort="sortNodes">
             <th><labrad-node-controller places={{places}} api={{api}} name={{node}}></labrad-node-controller></th>
           </template>
         </thead>
         <tbody>
-          <template is="dom-repeat" items="{{globalServersFiltered}}" as="server">
+          <template is="dom-repeat"
+                    items="{{globalServersFiltered}}"
+                    as="server">
             <tr>
               <td class='name'>{{server.name}}</td>
               <td class='version'>{{server.version}}</td>
-              <template is="dom-repeat" items="{{server.nodes}}" as="node">
+              <template is="dom-repeat"
+                        items="{{server.nodes}}"
+                        as="node"
+                        sort="sortNodes">
                 <td class='controls'>
                   <template is="dom-if" if="{{node.exists}}">
                     <labrad-instance-controller

--- a/client-js/app/elements/labrad-nodes.ts
+++ b/client-js/app/elements/labrad-nodes.ts
@@ -467,7 +467,7 @@ export class LabradNodes extends polymer.Base {
 
     this.updateNodeServerBinding('globalServersFiltered');
     this.updateNodeServerBinding('localServersFiltered');
-t 
+
     this.updateFilters();
   }
 

--- a/client-js/app/elements/labrad-nodes.ts
+++ b/client-js/app/elements/labrad-nodes.ts
@@ -511,8 +511,15 @@ export class LabradNodes extends polymer.Base {
 
     this.updateNodeServerBinding('globalServersFiltered');
     this.updateNodeServerBinding('localServersFiltered');
+    this.updateNodeServerBinding('globalServers');
+    this.updateNodeServerBinding('localServers');
 
-    this.updateFilters();
+    // If a node comes online that has a server marked as autostart that wasn't
+    // previously, and we are currently filtering, then we need to update the
+    // filters to show the new server(s).
+    if (this.isAutostartFiltered) {
+      this.updateFilters();
+    }
   }
 
   private removeItemFromList(item: ServerDisconnectMessage): void {
@@ -524,8 +531,15 @@ export class LabradNodes extends polymer.Base {
 
     this.updateNodeServerBinding('globalServersFiltered');
     this.updateNodeServerBinding('localServersFiltered');
+    this.updateNodeServerBinding('globalServers');
+    this.updateNodeServerBinding('localServers');
 
-    this.updateFilters();
+    // If a node goes offline that has a server marked as autostart that no
+    // other does, and we are currently filtering, then we need to update the
+    // filters to hide the invalid server(s).
+    if (this.isAutostartFiltered) {
+      this.updateFilters();
+    }
   }
 
 

--- a/client-js/app/elements/labrad-nodes.ts
+++ b/client-js/app/elements/labrad-nodes.ts
@@ -262,9 +262,6 @@ export class LabradNodes extends polymer.Base {
   @property({type: Object})
   managerApi: ManagerApi;
 
-  @property({type: Number, value: 0})
-  kick: number;
-
   @property({type: Boolean, value: false, notify: true})
   isAutostartFiltered: boolean;
 
@@ -470,7 +467,7 @@ export class LabradNodes extends polymer.Base {
 
     this.updateNodeServerBinding('globalServersFiltered');
     this.updateNodeServerBinding('localServersFiltered');
-
+t 
     this.updateFilters();
   }
 

--- a/client-js/app/elements/labrad-nodes.ts
+++ b/client-js/app/elements/labrad-nodes.ts
@@ -280,6 +280,9 @@ export class LabradNodes extends polymer.Base {
   @property({type: Object, value: []})
   localServersFiltered: ServerInfo[];
 
+  @property({type: Array, value: []})
+  nodeNames: String;
+
   private lifetime = new Lifetime();
 
   @listen('labrad-instance-controller::ready')
@@ -413,11 +416,16 @@ export class LabradNodes extends polymer.Base {
     return -1;
   }
 
+  sortNodes(a: string, b: string) {
+    if (a === b) return 0;
+    return a > b ? 1 : -1;
+  }
 
   addItemToList(item: NodeStatus): void {
     const idx = this.getNodeIndex(item, this.info);
     if (idx === -1) {
       this.push('info', item);
+      this.push('nodeNames', item.name);
     } else {
       this.splice('info', idx, 1, item);
     }
@@ -464,22 +472,19 @@ export class LabradNodes extends polymer.Base {
     this.updateNodeServerBinding('localServersFiltered');
 
     this.updateFilters();
-
-    this.kick++;
   }
 
   private removeItemFromList(item: ServerDisconnectMessage): void {
     const idx = this.getNodeIndex(item, this.info);
     if (idx !== -1) {
       this.splice('info', idx, 1);
+      this.splice('nodeNames', idx, 1);
     }
 
     this.updateNodeServerBinding('globalServersFiltered');
     this.updateNodeServerBinding('localServersFiltered');
 
     this.updateFilters();
-
-    this.kick++;
   }
 
 
@@ -590,13 +595,6 @@ export class LabradNodes extends polymer.Base {
   }
 
 
-  private _nodeNames(info: Array<NodeStatus>): Array<string> {
-    var names = info.map((n) => n.name);
-    names.sort();
-    return names;
-  }
-
-
   private _versionMap(info: Array<NodeStatus>): Map<string, Set<string>> {
     var versionMap = new Map<string, Set<string>>();
     for (let nodeStatus of info) {
@@ -608,11 +606,5 @@ export class LabradNodes extends polymer.Base {
       }
     }
     return versionMap;
-  }
-
-
-  @computed()
-  nodeNames(info: Array<NodeStatus>, kick: number): Array<string> {
-    return this._nodeNames(info)
   }
 }


### PR DESCRIPTION
Partial fix for #143. Attempting to move the code base away from computed properties and `kick` hacks, this keeps the same `nodeNames` functionality by keeping a list up-to-date rather than computing it on the fly.
