### PR TITLE
[#143, Part 4, Final] Fixes issue with nodes changing while view is filtered.

### DIFF
--- a/client-js/app/elements/labrad-nodes.ts
+++ b/client-js/app/elements/labrad-nodes.ts
@@ -467,8 +467,15 @@ export class LabradNodes extends polymer.Base {
 
     this.updateNodeServerBinding('globalServersFiltered');
     this.updateNodeServerBinding('localServersFiltered');
+    this.updateNodeServerBinding('globalServers');
+    this.updateNodeServerBinding('localServers');
 
-    this.updateFilters();
+    // If a node comes online that has a server marked as autostart that wasn't
+    // previously, and we are currently filtering, then we need to update the
+    // filters to show the new server(s).
+    if (this.isAutostartFiltered) {
+      this.updateFilters();
+    }
   }
 
   private removeItemFromList(item: ServerDisconnectMessage): void {
@@ -480,9 +487,17 @@ export class LabradNodes extends polymer.Base {
 
     this.updateNodeServerBinding('globalServersFiltered');
     this.updateNodeServerBinding('localServersFiltered');
+    this.updateNodeServerBinding('globalServers');
+    this.updateNodeServerBinding('localServers');
 
-    this.updateFilters();
+    // If a node goes offline that has a server marked as autostart that no
+    // other does, and we are currently filtering, then we need to update the
+    // filters to hide the invalid server(s).
+    if (this.isAutostartFiltered) {
+      this.updateFilters();
+    }
   }
+
 
 
   private _serverStatusMap(statuses: ServerStatus[]): Map<String, ServerStatus> {


### PR DESCRIPTION
Implements #143. Currently the view breaks if you are filtering to just autostart servers and then a node comes or goes offline. This fixes this issue by ensuring the `globalServers` and `localServers` lists are also being kept up-to-date, as they form the basis of the post-filtered list. 
