### PR TITLE
Bump polymer to version 1.6.x

### DIFF
--- a/client-js/bower.json
+++ b/client-js/bower.json
@@ -6,7 +6,7 @@
     "iron-elements": "PolymerElements/iron-elements#1.x",
     "neon-elements": "PolymerElements/neon-elements#1.x",
     "paper-elements": "PolymerElements/paper-elements#1.x",
-    "polymer": "Polymer/polymer#1.5.x",
+    "polymer": "Polymer/polymer#1.6.x",
     "polymer-ts": "nippur72/PolymerTS#0.1.x"
   },
   "devDependencies": {


### PR DESCRIPTION
The latest version of paper-checkbox wants polymer 1.6.x, so having it pinned to 1.5.x was breaking the teamcity build.
