### PR TITLE
[#272, Part 1] Add keyboard commands to traverse up and down registry keys.

### DIFF
--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -163,8 +163,6 @@
       <iron-a11y-keys target="[[target]]" keys="left backspace"
                       on-keys-pressed="cursorBack"></iron-a11y-keys>
       <table>
-
-
         <tbody is="selectable-table" id="combinedList" selected="{{selectedIdx}}">
           <template id="fullList" is="dom-repeat" items="{{listItems}}" filter="filterFunc">
             <tr name="{{item.name}}"

--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -156,7 +156,15 @@
   </style>
   <template>
     <div id="reg-area">
+      <iron-a11y-keys target="[[target]]" keys="up down"
+                      on-keys-pressed="cursorMove"></iron-a11y-keys>
+      <iron-a11y-keys target="[[target]]" keys="right enter"
+                      on-keys-pressed="cursorTraverse"></iron-a11y-keys>
+      <iron-a11y-keys target="[[target]]" keys="left backspace"
+                      on-keys-pressed="cursorBack"></iron-a11y-keys>
       <table>
+
+
         <tbody is="selectable-table" id="combinedList" selected="{{selectedIdx}}">
           <template id="fullList" is="dom-repeat" items="{{listItems}}" filter="filterFunc">
             <tr name="{{item.name}}"

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -44,13 +44,18 @@ export class LabradRegistry extends polymer.Base {
   }
 
 
-  getDefaultSelectedItem(): number {
+  getListOffset(): number {
     return this.path.length > 0 ? 1 : 0;
   }
 
 
+  getDefaultSelectedItem(): number {
+    return getListOffset();
+  }
+
+
   cursorMove(e) {
-    const offset = this.path.length > 0 ? 1 : 0;
+    const offset = this.getListOffset();
     const length = this.keys.length + this.dirs.length + offset;
 
     switch (e.detail.combo) {
@@ -163,7 +168,8 @@ export class LabradRegistry extends polymer.Base {
   selectedItem: string;
 
   _computeSelectedType(selectedIdx: number): string {
-    var offset = this.path.length > 0 ? 1 : 0; // account for parent '..' entry
+    // Account for parent '..' entry.
+    const offset = this.getListOffset();
     if (this.dirs && selectedIdx < this.dirs.length + offset) {
       return 'dir';
     } else {
@@ -172,9 +178,10 @@ export class LabradRegistry extends polymer.Base {
   }
 
   _computeSelectedItem(selectedIdx: number): string {
-    var offset = this.path.length > 0 ? 1 : 0; // account for parent '..' entry
-    var dirNames = (this.dirs || []).map(it => it.name);
-    var keyNames = (this.keys || []).map(it => it.name);
+    // Account for parent '..' entry.
+    const offset = this.getListOffset();
+    const dirNames = (this.dirs || []).map(it => it.name);
+    const keyNames = (this.keys || []).map(it => it.name);
     return dirNames.concat(keyNames)[selectedIdx - offset];
   }
 

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -104,7 +104,7 @@ export class LabradRegistry extends polymer.Base {
 
 
   /**
-   * On path change, select the 0th element and clear the filter.
+   * On path change, select the default element and clear the filter.
    */
   @observe('path')
   pathChanged(newPath: string[], oldPath: string[]) {

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -33,7 +33,7 @@ export class LabradRegistry extends polymer.Base {
 
   regex: RegExp; //regular expression for string comparison
 
-  target = document.body;
+  target: HTMLElement = document.body;
 
   attached() {
     this.bindIronAutogrowTextAreaResizeEvents(this.$.newKeyDialog,

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -87,7 +87,7 @@ export class LabradRegistry extends polymer.Base {
 
     // If we have a link, we want to traverse down.
     if (link) {
-      this.fire('app-link-click', {path: link.href});
+      this.fire('app-link-click', {path: link.path});
     }
   }
 

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -45,12 +45,12 @@ export class LabradRegistry extends polymer.Base {
 
 
   getDefaultSelectedItem(): number {
-    return this.path ? 1 : 0;
+    return this.path.length > 0 ? 1 : 0;
   }
 
 
   cursorMove(e) {
-    const offset = this.path ? 1 : 0;
+    const offset = this.path.length > 0 ? 1 : 0;
     const length = this.keys.length + this.dirs.length + offset;
 
     switch (e.detail.combo) {

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -153,11 +153,7 @@ export class LabradRegistry extends polymer.Base {
 
   @computed()
   selected(selectedIdx: number): boolean {
-    if (selectedIdx !== null) {
-      return true;
-    } else {
-      return false;
-    }
+    return (selectedIdx !== null);
   }
 
   @property({computed: '_computeSelectedType(selectedIdx)'})

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -45,12 +45,12 @@ export class LabradRegistry extends polymer.Base {
 
 
   getDefaultSelectedItem(): number {
-    return this.path.length > 0 ? 1 : 0;
+    return this.path ? 1 : 0;
   }
 
 
   cursorMove(e) {
-    const offset = this.path.length > 0 ? 1 : 0;
+    const offset = this.path ? 1 : 0;
     const length = this.keys.length + this.dirs.length + offset;
 
     switch (e.detail.combo) {

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -108,7 +108,6 @@ export class LabradRegistry extends polymer.Base {
    */
   @observe('path')
   pathChanged(newPath: string[], oldPath: string[]) {
-    const offset = newPath.length > 0 ? 1 : 0;
     this.set('selectedIdx', this.getDefaultSelectedItem());
     this.set('filterText', '');
   }

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -56,7 +56,7 @@ export class LabradRegistry extends polymer.Base {
     switch (e.detail.combo) {
       case 'up':
         if (this.selectedIdx === null || this.selectedIdx === 0) {
-          this.set('selectedIdx', null);
+          this.set('selectedIdx', 0);
         } else {
           this.set('selectedIdx', this.selectedIdx - 1);
         }

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -50,7 +50,7 @@ export class LabradRegistry extends polymer.Base {
 
 
   getDefaultSelectedItem(): number {
-    return getListOffset();
+    return this.getListOffset();
   }
 
 


### PR DESCRIPTION
Partially Implements #272. Added keyboard commands for traversing the registry directory structure:
- KEY_UP/KEY_DOWN: Move up and down the list of directories/keys.
- KEY_LEFT/KEY_BACKSPACE: Traverse to the parent directory.
- KEY_RIGHT/KEY_RETURN: Traverse to the child directory if a directory is selected.
