### PR TITLE
[#276] Add keyboard controls to traverse Grapher directory structure

### DIFF
--- a/client-js/app/elements/labrad-grapher.html
+++ b/client-js/app/elements/labrad-grapher.html
@@ -119,6 +119,12 @@
     }
   </style>
   <template>
+    <iron-a11y-keys target="[[target]]" keys="up down"
+                    on-keys-pressed="cursorMove"></iron-a11y-keys>
+    <iron-a11y-keys target="[[target]]" keys="right enter"
+                    on-keys-pressed="cursorTraverse"></iron-a11y-keys>
+    <iron-a11y-keys target="[[target]]" keys="left backspace"
+                    on-keys-pressed="cursorBack"></iron-a11y-keys>
     <div id="outer">
       <div id="container">
         <paper-header-panel id="left-column">
@@ -127,9 +133,11 @@
             <paper-icon-button icon="delete" id="trash" on-click="trashClicked" title="Show Trashed Items"></paper-icon-button>
           </div>
           <div id="listing">
-            <iron-list items="{{filteredListItems}}" as="item" class='fit'
-                                             selected-item="{{selected}}"
-                                             selection-enabled>
+            <iron-list items="{{filteredListItems}}"
+                       id="combinedList"
+                       as="item" class='fit'
+                       selected-item="{{selected}}"
+                       selection-enabled>
               <template>
                 <div class$='row [[computeSelectedClass(selected)]]'>
                   <div class="item">

--- a/client-js/app/elements/labrad-grapher.html
+++ b/client-js/app/elements/labrad-grapher.html
@@ -119,7 +119,7 @@
     }
   </style>
   <template>
-    <iron-a11y-keys target="[[target]]" keys="up down"
+    <iron-a11y-keys target="[[target]]" keys="up:keydown down:keydown"
                     on-keys-pressed="cursorMove"></iron-a11y-keys>
     <iron-a11y-keys target="[[target]]" keys="right enter"
                     on-keys-pressed="cursorTraverse"></iron-a11y-keys>

--- a/client-js/app/elements/labrad-grapher.ts
+++ b/client-js/app/elements/labrad-grapher.ts
@@ -85,22 +85,25 @@ export class LabradGrapher extends polymer.Base {
 
 
   cursorMove(e) {
-    const offset = this.path.length > 0 ? 1 : 0;
-    const length = this.filteredListItems.length + offset;
+    const length = this.filteredListItems.length;
     const selectedIndex = this.getSelectedIndex();
+    const list = this.$.combinedList;
 
     switch (e.detail.combo) {
       case 'up':
         if (selectedIndex !== null && selectedIndex !== 0) {
-          this.$.combinedList.selectItem(selectedIndex - 1);
+          list.selectItem(selectedIndex - 1);
+          list.scrollToIndex(selectedIndex - 1);
         }
         break;
 
       case 'down':
         if (selectedIndex === null) {
-          this.$.combinedList.selectItem(0);
+          list.selectItem(0);
+          list.scrollToIndex(0);
         } else if (selectedIndex < length - 1) {
-          this.$.combinedList.selectItem(selectedIndex + 1);
+          list.selectItem(selectedIndex + 1);
+          list.scrollToIndex(selectedIndex + 1);
         }
         break;
 

--- a/client-js/app/elements/labrad-grapher.ts
+++ b/client-js/app/elements/labrad-grapher.ts
@@ -84,6 +84,19 @@ export class LabradGrapher extends polymer.Base {
   }
 
 
+  scrollToIndex(index: number) {
+    const list = this.$.combinedList;
+    const first = list.firstVisibleIndex;
+    const last = list.lastVisibleIndex;
+
+    if (index < first) {
+      list.scrollToIndex(index);
+    } else if (index > last) {
+      list.scrollToIndex(index - (last - first));
+    }
+  }
+
+
   cursorMove(e) {
     const length = this.filteredListItems.length;
     const selectedIndex = this.getSelectedIndex();
@@ -93,17 +106,17 @@ export class LabradGrapher extends polymer.Base {
       case 'up':
         if (selectedIndex !== null && selectedIndex !== 0) {
           list.selectItem(selectedIndex - 1);
-          list.scrollToIndex(selectedIndex - 1);
+          this.scrollToIndex(selectedIndex - 1);
         }
         break;
 
       case 'down':
         if (selectedIndex === null) {
           list.selectItem(0);
-          list.scrollToIndex(0);
+          this.scrollToIndex(0);
         } else if (selectedIndex < length - 1) {
           list.selectItem(selectedIndex + 1);
-          list.scrollToIndex(selectedIndex + 1);
+          this.scrollToIndex(selectedIndex + 1);
         }
         break;
 

--- a/client-js/app/elements/labrad-plot.html
+++ b/client-js/app/elements/labrad-plot.html
@@ -55,6 +55,8 @@
     }
   </style>
   <template>
+    <iron-a11y-keys target="[[target]]" keys="left backspace"
+                    on-keys-pressed="cursorBack"></iron-a11y-keys>
     <div id="plot"></div>
     <div id="canvas"></div>
     <div id="zoomRectangle"></div>

--- a/client-js/app/elements/labrad-plot.ts
+++ b/client-js/app/elements/labrad-plot.ts
@@ -69,7 +69,6 @@ const COLOR_BAR_WIDGET_SIZE = (
 
 @component('labrad-plot')
 export class Plot extends polymer.Base {
-
   @property({type: String, value: ''})
   xLabel: string;
 
@@ -90,6 +89,9 @@ export class Plot extends polymer.Base {
 
   @property({type: Array})
   deps: {label: string, legend: string, unit: string}[];
+
+  @property({type: String})
+  backUrl: string;
 
   private lifetime = new Lifetime();
 
@@ -240,6 +242,17 @@ export class Plot extends polymer.Base {
 
   /** Store the canvas' bounding rectangle for performance. */
   private canvasBoundingRect = null;
+
+  target: HTMLElement = document.body;
+
+
+  /**
+   * Navigate back to the directory listing.
+   */
+  cursorBack(e) {
+    this.fire('app-link-click', {path: this.backUrl});
+  }
+
 
   /**
    * Add new data to the plot and re-zoom.

--- a/client-js/app/scripts/activities.ts
+++ b/client-js/app/scripts/activities.ts
@@ -311,6 +311,7 @@ export class DatasetActivity implements Activity {
     var elem: HTMLElement = null;
     if (info.independents.length <= 2) {
       let plot = <Plot> Plot.create();
+      plot.backUrl = this.places.grapherUrl(this.path.slice(0, -1));
       plot.setAttribute('class', 'flex');
       plot.numIndeps = info.independents.length;
       plot.xLabel = datavault.makeAxisLabel(info.independents[0]);

--- a/client-js/app/scripts/activities.ts
+++ b/client-js/app/scripts/activities.ts
@@ -311,7 +311,7 @@ export class DatasetActivity implements Activity {
     var elem: HTMLElement = null;
     if (info.independents.length <= 2) {
       let plot = <Plot> Plot.create();
-      plot.backUrl = this.places.grapherUrl(this.path.slice(0, -1));
+      plot.backUrl = this.places.grapherUrl(this.path);
       plot.setAttribute('class', 'flex');
       plot.numIndeps = info.independents.length;
       plot.xLabel = datavault.makeAxisLabel(info.independents[0]);


### PR DESCRIPTION
Resolves #276. Added keyboard commands for traversing the Grapher directory structure:
- KEY_UP/KEY_DOWN: Move up and down the list of directories/keys.
- KEY_LEFT/KEY_BACKSPACE: Traverse to the parent directory.
- KEY_RIGHT/KEY_RETURN: Traverse to the child directory if a directory is selected.

Traversing to the parent directory continues to work from the Plot view as well as while on the directory view.
