### PR TITLE
[#272, Part 2, Final] Add keyboard controls for editing Registry keys.

### DIFF
--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -97,15 +97,30 @@
       padding: 0px 10px;
       flex-grow: 1;
       text-align: right;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
     #search-bar paper-input {
       font-family: var(--primary-font-family);
-      font-size: 15px;
       width: calc(100% - 50px);
       border: 0;
       border-radius: 2px;
       -webkit-appearance: none;
       display: inline-block;
+      text-align: left;
+      --paper-font-caption: {
+        display: none;
+      }
+      --layout-center: {
+        background-color: #fff;
+        align-items: center;
+      }
+      --paper-input-container-input: {
+        line-height: 24px;
+        padding: 10px;
+        width: calc(100% - 20px);
+      }
     }
     .mono {
       font-family: 'roboto mono', monospace;
@@ -240,8 +255,10 @@
           delete
         </paper-button>
         <div id="search-bar">
-          <iron-icon icon="search"></iron-icon>
-          <paper-input id="search" value="{{filterText::input}}" label="Search Registry"></paper-input>
+          <paper-input id="search" value="{{filterText::input}}"
+            noLabelFloat>
+            <iron-icon icon="search" prefix></iron-icon>
+          </paper-input>
         </div>
       </paper-toolbar>
     </div>

--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -98,14 +98,14 @@
       flex-grow: 1;
       text-align: right;
     }
-    #search-bar input {
+    #search-bar paper-input {
       font-family: var(--primary-font-family);
       font-size: 15px;
       width: calc(100% - 50px);
-      padding: 10px;
       border: 0;
       border-radius: 2px;
       -webkit-appearance: none;
+      display: inline-block;
     }
     .mono {
       font-family: 'roboto mono', monospace;
@@ -168,6 +168,9 @@
                       on-keys-pressed="dialogCancel"></iron-a11y-keys>
       <iron-a11y-keys target="[[target]]" keys="shift+enter"
                       on-keys-pressed="dialogSubmit"></iron-a11y-keys>
+      <!-- Search Controls -->
+      <iron-a11y-keys target="[[target]]" keys="enter"
+                      on-keys-pressed="searchSubmit"></iron-a11y-keys>
       <table>
         <tbody is="selectable-table" id="combinedList" selected="{{selectedIdx}}">
           <template id="fullList" is="dom-repeat" items="{{listItems}}" filter="filterFunc">
@@ -238,7 +241,7 @@
         </paper-button>
         <div id="search-bar">
           <iron-icon icon="search"></iron-icon>
-          <input type="search" id="search" value="{{filterText::input}}" placeholder="search registry">
+          <paper-input id="search" value="{{filterText::input}}" label="Search Registry"></paper-input>
         </div>
       </paper-toolbar>
     </div>

--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -248,7 +248,7 @@
     <paper-dialog id="newKeyDialog" modal>
       <h1>Create New Key</h1>
       <form>
-        <paper-input id="newKeyInput" label="Key"></paper-input>
+        <paper-input id="newKeyInput" label="Key" autofocus></paper-input>
         <paper-textarea id="newValueInput" label="Value"></paper-textarea>
       </form>
       <div class="buttons">
@@ -271,10 +271,10 @@
     <paper-dialog id="newFolderDialog" modal>
       <h1>Create New Folder</h1>
       <form>
-        <paper-input id="newFolderInput" label="Name"></paper-input>
+        <paper-input id="newFolderInput" label="Name" autofocus></paper-input>
       </form>
       <div class="buttons">
-        <paper-button on-click="doNewFolder" dialog-confirm autofocus>OK</paper-button>
+        <paper-button on-click="doNewFolder" dialog-confirm>OK</paper-button>
         <paper-button dialog-dismiss>CANCEL</paper-button>
       </div>
     </paper-dialog>
@@ -294,7 +294,7 @@
     <paper-dialog id="copyDialog" modal>
       <h1>Copy <span>{{selectedType}}</span> "<span>{{selectedItem}}</span>"?</h1>
       <form>
-        <paper-input id="copyNameInput" label="New Name" always-float-label></paper-input>
+        <paper-input id="copyNameInput" label="New Name" always-float-label autofocus></paper-input>
         <paper-input id="copyPathInput" label="New Path" always-float-label></paper-input>
       </form>
       <div class="buttons">
@@ -306,10 +306,10 @@
     <paper-dialog id="renameDialog" modal>
       <h1>Rename <span>{{selectedType}}</span> "<span>{{selectedItem}}</span>"?</h1>
       <form>
-        <paper-input id="renameInput" label="New Name" always-float-label></paper-input>
+        <paper-input id="renameInput" label="New Name" always-float-label autofocus></paper-input>
       </form>
       <div class="buttons">
-        <paper-button on-click="doRename" dialog-confirm autofocus>OK</paper-button>
+        <paper-button on-click="doRename" dialog-confirm>OK</paper-button>
         <paper-button dialog-dismiss>CANCEL</paper-button>
       </div>
     </paper-dialog>

--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -156,17 +156,24 @@
   </style>
   <template>
     <div id="reg-area">
+      <!-- Cursor Controls -->
       <iron-a11y-keys target="[[target]]" keys="up down"
                       on-keys-pressed="cursorMove"></iron-a11y-keys>
       <iron-a11y-keys target="[[target]]" keys="right enter"
                       on-keys-pressed="cursorTraverse"></iron-a11y-keys>
       <iron-a11y-keys target="[[target]]" keys="left backspace"
                       on-keys-pressed="cursorBack"></iron-a11y-keys>
+      <!-- Dialog Controls -->
+      <iron-a11y-keys target="[[target]]" keys="esc"
+                      on-keys-pressed="dialogCancel"></iron-a11y-keys>
+      <iron-a11y-keys target="[[target]]" keys="shift+enter"
+                      on-keys-pressed="dialogSubmit"></iron-a11y-keys>
       <table>
         <tbody is="selectable-table" id="combinedList" selected="{{selectedIdx}}">
           <template id="fullList" is="dom-repeat" items="{{listItems}}" filter="filterFunc">
             <tr name="{{item.name}}"
                 key-name="{{item.name}}"
+                key-value="{{item.value}}"
                 is-key="{{item.isKey}}"
                 on-dblclick="editValueClicked">
               <template is="dom-if" if="{{item.isParent}}">
@@ -253,10 +260,10 @@
     <paper-dialog id="editValueDialog" modal>
       <h1>Edit <span>{{selectedItem}}</span></h1>
       <form>
-        <paper-textarea id="editValueInput" label="Value"></paper-textarea>
+        <paper-textarea id="editValueInput" label="Value" autofocus></paper-textarea>
       </form>
       <div class="buttons">
-        <paper-button on-click="doEditValue" dialog-confirm autofocus>OK</paper-button>
+        <paper-button on-click="doEditValue" dialog-confirm>OK</paper-button>
         <paper-button dialog-dismiss>CANCEL</paper-button>
       </div>
     </paper-dialog>

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -221,6 +221,8 @@ export class LabradRegistry extends polymer.Base {
    * that contain substring in filterText
    */
   filterFunc(item) {
+    const selectedIdx = (this.$.search.value) ? 0 : this.getDefaultSelectedItem();
+    this.set('selectedIdx', selectedIdx);
     return item.name.match(this.regex);
   }
 

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -160,23 +160,23 @@ export class LabradRegistry extends polymer.Base {
     switch (dialog.id) {
       case 'newKeyDialog':
         this.doNewKey();
-        break
+        break;
 
       case 'newFolderDialog':
         this.doNewFolder();
-        break
+        break;
 
       case 'editValueDialog':
         this.doEditValue();
-        break
+        break;
 
       case 'renameDialog':
         this.doRename();
-        break
+        break;
 
       case 'copyDialog':
         this.doCopy();
-        break
+        break;
 
       default:
         // Nothing to do.

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -516,7 +516,6 @@ export class LabradRegistry extends polymer.Base {
         newFolderElem = this.$.newFolderInput;
     newFolderElem.value = '';
     dialog.open();
-    window.setTimeout(() => newFolderElem.$.input.focus(), 0);
   }
 
   /**
@@ -549,7 +548,6 @@ export class LabradRegistry extends polymer.Base {
     copyNameElem.value = this.selectedItem;
     copyPathElem.value = this.pathToString(this.path);
     dialog.open();
-    window.setTimeout(() => copyNameElem.$.input.focus(), 0);
   }
 
   /**
@@ -637,7 +635,6 @@ export class LabradRegistry extends polymer.Base {
 
     renameElem.value = name;
     dialog.open();
-    window.setTimeout(() => renameElem.$.input.focus(), 0);
   }
 
   /**

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -42,7 +42,7 @@ export class LabradRegistry extends polymer.Base {
     'dragDialog',
     'copyDialog',
     'renameDialog',
-    'deleteDialog'
+    'deleteDialog',
     'pendingDialog',
   ];
 
@@ -65,7 +65,7 @@ export class LabradRegistry extends polymer.Base {
   }
 
 
-  private getOpenDialog(): HTMLElement {
+  private getOpenDialog() {
     for (const dialog of this.dialogs) {
       if (this.$[dialog].opened) {
         return this.$[dialog];
@@ -138,21 +138,50 @@ export class LabradRegistry extends polymer.Base {
 
 
   dialogSubmit(event) {
-    if (!this.getOpenDialog()) {
+    const dialog = this.getOpenDialog();
+    if (!dialog) {
       return;
     }
+
     event.detail.keyboardEvent.preventDefault();
-    this.doEditValue();
-    this.$.editValueDialog.close();
+
+    switch (dialog.id) {
+      case 'newKeyDialog':
+        this.doNewKey();
+        break
+
+      case 'newFolderDialog':
+        this.doNewFolder();
+        break
+
+      case 'editValueDialog':
+        this.doEditValue();
+        break
+
+      case 'renameDialog':
+        this.doRename();
+        break
+
+      case 'copyDialog':
+        this.doCopy();
+        break
+
+      default:
+        // Nothing to do.
+        break;
+    }
+
+    dialog.close();
   }
 
 
   dialogCancel(event) {
-    if (!this.getOpenDialog()) {
+    const dialog = this.getOpenDialog();
+    if (!dialog) {
       return;
     }
     event.detail.keyboardEvent.preventDefault();
-    this.$.editValueDialog.close();
+    dialog.close();
   }
 
 

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -80,6 +80,7 @@ export class LabradRegistry extends polymer.Base {
       return;
     }
 
+    this.searchSubmit();
     event.detail.keyboardEvent.preventDefault();
 
     const offset = this.getListOffset();
@@ -110,11 +111,15 @@ export class LabradRegistry extends polymer.Base {
 
 
   cursorTraverse(event) {
-    if (this.selectedIdx === null || this.getOpenDialog()) {
+    if (this.selectedIdx === null || this.getOpenDialog() || this.$.search.focused) {
       return;
     }
 
     const item = this.$.combinedList.selectedItem;
+    if (!item) {
+      return;
+    }
+
     const link = item.querySelector('a');
 
     // If we have a link, we want to traverse down.
@@ -127,13 +132,20 @@ export class LabradRegistry extends polymer.Base {
 
 
   cursorBack(event) {
-    if (this.path.length === 0 || this.getOpenDialog()) {
+    if (this.path.length === 0 || this.getOpenDialog() || this.$.search.focused) {
       return;
     }
 
     const parentPath = this.path.slice(0, -1);
     const parentUrl = this.places.registryUrl(parentPath);
     this.fire('app-link-click', {path: parentUrl});
+  }
+
+
+  searchSubmit() {
+    if (this.$.search.focused) {
+      this.$.search.inputElement.blur();
+    }
   }
 
 

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -35,6 +35,17 @@ export class LabradRegistry extends polymer.Base {
 
   target: HTMLElement = document.body;
 
+  private dialogs: string[] = [
+    'newKeyDialog',
+    'editValueDialog',
+    'newFolderDialog',
+    'dragDialog',
+    'copyDialog',
+    'renameDialog',
+    'deleteDialog'
+    'pendingDialog',
+  ];
+
   attached() {
     this.bindIronAutogrowTextAreaResizeEvents(this.$.newKeyDialog,
                                               this.$.newValueInput);
@@ -53,12 +64,19 @@ export class LabradRegistry extends polymer.Base {
     return this.getListOffset();
   }
 
-  private hasDialogOpen() {
-    return (this.$.editValueDialog.opened);
+
+  private getOpenDialog(): HTMLElement {
+    for (const dialog of this.dialogs) {
+      if (this.$[dialog].opened) {
+        return this.$[dialog];
+      }
+    }
+    return null;
   }
 
+
   cursorMove(event) {
-    if (this.hasDialogOpen()) {
+    if (this.getOpenDialog()) {
       return;
     }
 
@@ -92,7 +110,7 @@ export class LabradRegistry extends polymer.Base {
 
 
   cursorTraverse(event) {
-    if (this.selectedIdx === null || this.hasDialogOpen()) {
+    if (this.selectedIdx === null || this.getOpenDialog()) {
       return;
     }
 
@@ -109,7 +127,7 @@ export class LabradRegistry extends polymer.Base {
 
 
   cursorBack(event) {
-    if (this.path.length === 0 || this.hasDialogOpen()) {
+    if (this.path.length === 0 || this.getOpenDialog()) {
       return;
     }
 
@@ -120,7 +138,7 @@ export class LabradRegistry extends polymer.Base {
 
 
   dialogSubmit(event) {
-    if (!this.hasDialogOpen()) {
+    if (!this.getOpenDialog()) {
       return;
     }
     event.detail.keyboardEvent.preventDefault();
@@ -130,7 +148,7 @@ export class LabradRegistry extends polymer.Base {
 
 
   dialogCancel(event) {
-    if (!this.hasDialogOpen()) {
+    if (!this.getOpenDialog()) {
       return;
     }
     event.detail.keyboardEvent.preventDefault();
@@ -407,6 +425,7 @@ export class LabradRegistry extends polymer.Base {
       this.handleError('Cannot create key with empty name');
     }
   }
+
 
   private editValueSelected() {
     const item = this.$.combinedList.selectedItem;

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -241,7 +241,7 @@ export class LabradRegistry extends polymer.Base {
   @property({computed: '_computeSelectedType(selectedIdx)'})
   selectedType: string;
 
-  @property({computed: '_computeSelectedItem(selectedIdx)'})
+  @property({computed: '_computeSelectedItem(selectedIdx, kick)'})
   selectedItem: string;
 
   _computeSelectedType(selectedIdx: number): string {
@@ -254,7 +254,7 @@ export class LabradRegistry extends polymer.Base {
     }
   }
 
-  _computeSelectedItem(selectedIdx: number): string {
+  _computeSelectedItem(selectedIdx: number, kick: number): string {
     // Account for parent '..' entry.
     const offset = this.getListOffset();
     const dirNames = (this.dirs || []).map(it => it.name);

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -415,13 +415,7 @@ export class LabradRegistry extends polymer.Base {
 
     editValueElem.value = item.keyValue;
     dialog.keyName = item.keyName;
-    this.openEditDialog();
-  }
-
-
-  private openEditDialog() {
-    this.$.editValueDialog.open();
-    this.async(() => { this.$.editValueInput.focus(); });
+    dialog.open();
   }
 
 
@@ -448,7 +442,7 @@ export class LabradRegistry extends polymer.Base {
     }
     editValueElem.value = value;
     dialog.keyName = name;
-    this.openEditDialog();
+    dialog.open();
   }
 
 


### PR DESCRIPTION
Implements #272 (along with PR #275). Added keyboard commands for editing keys in the Registry.
- KEY_RIGHT/KEY_RETURN: Edit the selected key.
- KEY_SHIFT+KEY_ENTER: Submit edit.
- KEY_ESCAPE: Close dialog without submitting.

Other interactions:
- KEY_RIGHT/KEY_RETURN/KEY_LEFT/KEY_BACKSPACE: Disabled when search is selected.
- KEY_RETURN: Will unfocus the search when selected.
- KEY_UP/KEY_DOWN: Will still navigate when search is selected, and will blur the search if used.
