### PR TITLE
[#278] Change Registry to use iron-list.

### DIFF
--- a/client-js/app/elements/labrad-grapher.ts
+++ b/client-js/app/elements/labrad-grapher.ts
@@ -34,9 +34,6 @@ export class LabradGrapher extends polymer.Base {
   @property({type: Object, notify: true})
   selected: ListItem;
 
-  @property({type: Number, notify: true})
-  selectedIndex: number;
-
   @property({type: Object})
   selectedDatasetInfo: datavault.DatasetInfo = null;
 

--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -61,7 +61,7 @@
       -webkit-user-select: none;
     }
     .row .key {
-      width: 400px;
+      width: 16em;
       white-space: nowrap;
       padding-right: 2em;
       overflow: hidden;
@@ -259,8 +259,8 @@
                 <div class="key mono"
                      name="{{item.name}}"
                      draggable="true">
-                  <iron-icon icon="communication:vpn-key" item-icon></iron-icon>
-                  <span>{{item.name}}</span>
+                  <iron-icon icon="communication:vpn-key"item-icon></iron-icon>
+                  <span title="{{item.name}}">{{item.name}}</span>
                 </div>
                 <div class="value label-wide mono">
                   <span>{{item.value}}</span>

--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -181,7 +181,7 @@
       <!-- Dialog Controls -->
       <iron-a11y-keys target="[[target]]" keys="esc"
                       on-keys-pressed="dialogCancel"></iron-a11y-keys>
-      <iron-a11y-keys target="[[target]]" keys="shift+enter"
+      <iron-a11y-keys target="[[target]]" keys="shift+enter enter"
                       on-keys-pressed="dialogSubmit"></iron-a11y-keys>
       <!-- Cursor Controls -->
       <iron-a11y-keys target="[[target]]" keys="up down"
@@ -277,10 +277,8 @@
 
     <paper-dialog id="newKeyDialog" modal>
       <h1>Create New Key</h1>
-      <form>
-        <paper-input id="newKeyInput" label="Key" autofocus></paper-input>
-        <paper-textarea id="newValueInput" label="Value"></paper-textarea>
-      </form>
+      <paper-input id="newKeyInput" label="Key" autofocus></paper-input>
+      <paper-textarea id="newValueInput" label="Value"></paper-textarea>
       <div class="buttons">
         <paper-button on-tap="doNewKey" dialog-confirm>OK</paper-button>
         <paper-button dialog-dismiss>CANCEL</paper-button>
@@ -289,9 +287,7 @@
 
     <paper-dialog id="editValueDialog" modal>
       <h1>Edit <span>{{selected.name}}</span></h1>
-      <form>
-        <paper-textarea id="editValueInput" label="Value" autofocus></paper-textarea>
-      </form>
+      <paper-textarea id="editValueInput" label="Value" autofocus></paper-textarea>
       <div class="buttons">
         <paper-button on-tap="doEditValue" dialog-confirm>OK</paper-button>
         <paper-button dialog-dismiss>CANCEL</paper-button>
@@ -300,9 +296,7 @@
 
     <paper-dialog id="newFolderDialog" modal>
       <h1>Create New Folder</h1>
-      <form>
-        <paper-input id="newFolderInput" label="Name" autofocus></paper-input>
-      </form>
+      <paper-input id="newFolderInput" label="Name" autofocus></paper-input>
       <div class="buttons">
         <paper-button on-tap="doNewFolder" dialog-confirm>OK</paper-button>
         <paper-button dialog-dismiss>CANCEL</paper-button>
@@ -311,10 +305,8 @@
 
      <paper-dialog id="dragDialog" modal>
       <h1><span id="dragOp"></span> <span id="dragClass"></span> "<span id="originName"></span>" from <span id="originPath"></span></h1>
-      <form>
-        <paper-input id="dragNameInput" label="New Name" always-float-label></paper-input>
-        <paper-input id="dragPathInput" label="New Path" always-float-label></paper-input>
-      </form>
+      <paper-input id="dragNameInput" label="New Name" always-float-label></paper-input>
+      <paper-input id="dragPathInput" label="New Path" always-float-label></paper-input>
       <div class="buttons">
         <paper-button on-tap="doDragOp" dialog-confirm>OK</paper-button>
         <paper-button dialog-dismiss>CANCEL</paper-button>
@@ -323,10 +315,8 @@
 
     <paper-dialog id="copyDialog" modal>
       <h1>Copy <span>{{selectedType}}</span> "<span>{{selected.name}}</span>"?</h1>
-      <form>
-        <paper-input id="copyNameInput" label="New Name" always-float-label autofocus></paper-input>
-        <paper-input id="copyPathInput" label="New Path" always-float-label></paper-input>
-      </form>
+      <paper-input id="copyNameInput" label="New Name" always-float-label autofocus></paper-input>
+      <paper-input id="copyPathInput" label="New Path" always-float-label></paper-input>
       <div class="buttons">
         <paper-button on-tap="doCopy" dialog-confirm>OK</paper-button>
         <paper-button dialog-dismiss>CANCEL</paper-button>
@@ -335,9 +325,7 @@
 
     <paper-dialog id="renameDialog" modal>
       <h1>Rename <span>{{selectedType}}</span> "<span>{{selected.name}}</span>"?</h1>
-      <form>
-        <paper-input id="renameInput" label="New Name" always-float-label autofocus></paper-input>
-      </form>
+      <paper-input id="renameInput" label="New Name" always-float-label autofocus></paper-input>
       <div class="buttons">
         <paper-button on-tap="doRename" dialog-confirm>OK</paper-button>
         <paper-button dialog-dismiss>CANCEL</paper-button>

--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -282,7 +282,7 @@
         <paper-textarea id="newValueInput" label="Value"></paper-textarea>
       </form>
       <div class="buttons">
-        <paper-button on-click="doNewKey" dialog-confirm>OK</paper-button>
+        <paper-button on-tap="doNewKey" dialog-confirm>OK</paper-button>
         <paper-button dialog-dismiss>CANCEL</paper-button>
       </div>
     </paper-dialog>
@@ -293,7 +293,7 @@
         <paper-textarea id="editValueInput" label="Value" autofocus></paper-textarea>
       </form>
       <div class="buttons">
-        <paper-button on-click="doEditValue" dialog-confirm>OK</paper-button>
+        <paper-button on-tap="doEditValue" dialog-confirm>OK</paper-button>
         <paper-button dialog-dismiss>CANCEL</paper-button>
       </div>
     </paper-dialog>
@@ -304,7 +304,7 @@
         <paper-input id="newFolderInput" label="Name" autofocus></paper-input>
       </form>
       <div class="buttons">
-        <paper-button on-click="doNewFolder" dialog-confirm>OK</paper-button>
+        <paper-button on-tap="doNewFolder" dialog-confirm>OK</paper-button>
         <paper-button dialog-dismiss>CANCEL</paper-button>
       </div>
     </paper-dialog>
@@ -316,7 +316,7 @@
         <paper-input id="dragPathInput" label="New Path" always-float-label></paper-input>
       </form>
       <div class="buttons">
-        <paper-button on-click="doDragOp" dialog-confirm>OK</paper-button>
+        <paper-button on-tap="doDragOp" dialog-confirm>OK</paper-button>
         <paper-button dialog-dismiss>CANCEL</paper-button>
       </div>
     </paper-dialog>
@@ -328,7 +328,7 @@
         <paper-input id="copyPathInput" label="New Path" always-float-label></paper-input>
       </form>
       <div class="buttons">
-        <paper-button on-click="doCopy" dialog-confirm>OK</paper-button>
+        <paper-button on-tap="doCopy" dialog-confirm>OK</paper-button>
         <paper-button dialog-dismiss>CANCEL</paper-button>
       </div>
     </paper-dialog>
@@ -339,7 +339,7 @@
         <paper-input id="renameInput" label="New Name" always-float-label autofocus></paper-input>
       </form>
       <div class="buttons">
-        <paper-button on-click="doRename" dialog-confirm>OK</paper-button>
+        <paper-button on-tap="doRename" dialog-confirm>OK</paper-button>
         <paper-button dialog-dismiss>CANCEL</paper-button>
       </div>
     </paper-dialog>
@@ -347,7 +347,7 @@
     <paper-dialog id="deleteDialog" modal>
       <h1>Delete <span>{{selectedType}}</span> "<span>{{selected.name}}</span>"?</h1>
       <div class="buttons">
-        <paper-button on-click="doDelete" dialog-confirm autofocus>OK</paper-button>
+        <paper-button on-tap="doDelete" dialog-confirm autofocus>OK</paper-button>
         <paper-button dialog-dismiss>CANCEL</paper-button>
       </div>
     </paper-dialog>

--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -171,7 +171,7 @@
                       on-keys-pressed="cursorBack"></iron-a11y-keys>
 
       <div id="listing">
-        <iron-list items="[[listItems]]"
+        <iron-list items="[[filteredListItems]]"
                   id="combinedList"
                   as="item"
                   selected-item="{{selected}}"

--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -1,12 +1,14 @@
 <link rel="import" href="../bower_components/paper-input/paper-textarea.html">
 <link rel="import" href="../bower_components/paper-toast/paper-toast.html">
+<link rel="import" href="../bower_components/iron-list/iron-list.html">
 
 <!-- This is the component that simply renders the table of registry content -->
 <dom-module id="labrad-registry">
   <style>
     :host {
-      display: block;
-      width: 100%;
+      height: 100%;
+      overflow: hidden;
+      display: flex;
     }
 
     #reg-menu {
@@ -25,7 +27,7 @@
       width: 100%;
     }
 
-    tbody tr:nth-child(1n).iron-selected {
+    .row:nth-child(1n).iron-selected {
       background-color: #CCCCCC;
     }
 
@@ -48,13 +50,13 @@
     td.dir.over {
       background-color: #93d4d4;
     }
-    tbody tr:nth-child(odd) {
+    .row:nth-child(odd) {
       background-color: #EEEEEE;
     }
-    tbody tr:nth-child(odd):hover {
+    .row:nth-child(odd):hover {
       background-color: #F6F699;
     }
-    tbody tr:nth-child(even):hover {
+    .row:nth-child(even):hover {
       background-color: #FFFFAA;
     }
 
@@ -153,8 +155,28 @@
     .label-wide .back-link:visited:hover {
       color: #3f51b5;
     }
+    #outer {
+      display: flex;
+      flex-direction: column;
+      position: relative;
+      width: 100%;
+    }
+    #reg-area, #listing, #combinedList {
+      flex: 1;
+      display: flex;
+      width: 100%;
+    }
+    .row {
+      width: 100%;
+    }
+    iron-list {
+      --iron-list-items-container: {
+        width: 100%;
+      };
+    }
   </style>
   <template>
+  <div id="outer">
     <div id="reg-area">
       <iron-a11y-keys target="[[target]]" keys="up down"
                       on-keys-pressed="cursorMove"></iron-a11y-keys>
@@ -162,24 +184,29 @@
                       on-keys-pressed="cursorTraverse"></iron-a11y-keys>
       <iron-a11y-keys target="[[target]]" keys="left backspace"
                       on-keys-pressed="cursorBack"></iron-a11y-keys>
-      <table>
-        <tbody is="selectable-table" id="combinedList" selected="{{selectedIdx}}">
-          <template id="fullList" is="dom-repeat" items="{{listItems}}" filter="filterFunc">
-            <tr name="{{item.name}}"
+
+      <div id="listing">
+        <iron-list items="[[listItems]]"
+                  id="combinedList"
+                  as="item"
+                  selected-item="{{selected}}"
+                  selection-enabled>
+          <template>
+            <div class$="row [[computeSelectedClass(selected)]]"
+                on-dblclick="editValueClicked"
+                name="{{item.name}}"
                 key-name="{{item.name}}"
-                is-key="{{item.isKey}}"
-                on-dblclick="editValueClicked">
+                is-key="{{item.isKey}}">
               <template is="dom-if" if="{{item.isParent}}">
-                <td class="label-wide" colspan="2">
+                <div class="label-wide">
                   <a class='back-link' is="app-link" path="{{item.url}}" href="{{item.url}}">
                     <iron-icon icon="arrow-back" item-icon></iron-icon>
                     <span>{{item.name}}</span>
                   </a>
-                </td>
+                </div>
               </template>
               <template is="dom-if" if="{{item.isDir}}">
-                <td class="dir label-wide"
-                    colspan="2"
+                <div class="dir label-wide"
                     name="{{item.name}}"
                     draggable="true"
                     on-dragover="onDirDragOver"
@@ -189,23 +216,23 @@
                     <iron-icon icon="folder" item-icon class="folder"></iron-icon>
                     <span>{{item.name}}</span>
                   </a>
-                </td>
+                </div>
               </template>
               <template is="dom-if" if="{{item.isKey}}">
-                <td class="key mono"
+                <div class="key mono"
                     name="{{item.name}}"
                     draggable="true">
                   <iron-icon icon="communication:vpn-key" item-icon class="key"></iron-icon>
                   <span>{{item.name}}</span>
-                </td>
-                <td class="value label-wide mono">
+                </div>
+                <div class="value label-wide mono">
                   <span>{{item.value}}</span>
-                </td>
+                </div>
               </template>
-            </tr>
+            </div>
           </template>
-        </tbody>
-      </table>
+        </iron-list>
+      </div>
     </div>
     <div id="reg-menu">
       <paper-toolbar>
@@ -217,15 +244,15 @@
           <iron-icon icon="folder-open"></iron-icon>
           new dir
         </paper-button>
-        <paper-button on-click="copyClicked" disabled="{{!selected}}">
+        <paper-button on-click="copyClicked" disabled="[[!selected]]">
           <iron-icon icon="content-copy"></iron-icon>
           copy
         </paper-button>
-        <paper-button on-click="renameClicked" disabled="{{!selected}}">
+        <paper-button on-click="renameClicked" disabled="[[!selected]]">
           <iron-icon icon="code"></iron-icon>
           rename
         </paper-button>
-        <paper-button on-click="deleteClicked" disabled="{{!selected}}">
+        <paper-button on-click="deleteClicked" disabled="[[!selected]]">
           <iron-icon icon="delete"></iron-icon>
           delete
         </paper-button>
@@ -251,7 +278,7 @@
     </paper-dialog>
 
     <paper-dialog id="editValueDialog" modal>
-      <h1>Edit <span>{{selectedItem}}</span></h1>
+      <h1>Edit <span>{{selected}}</span></h1>
       <form>
         <paper-textarea id="editValueInput" label="Value"></paper-textarea>
       </form>
@@ -285,7 +312,7 @@
     </paper-dialog>
 
     <paper-dialog id="copyDialog" modal>
-      <h1>Copy <span>{{selectedType}}</span> "<span>{{selectedItem}}</span>"?</h1>
+      <h1>Copy <span>{{selectedType}}</span> "<span>{{selected}}</span>"?</h1>
       <form>
         <paper-input id="copyNameInput" label="New Name" always-float-label></paper-input>
         <paper-input id="copyPathInput" label="New Path" always-float-label></paper-input>
@@ -297,7 +324,7 @@
     </paper-dialog>
 
     <paper-dialog id="renameDialog" modal>
-      <h1>Rename <span>{{selectedType}}</span> "<span>{{selectedItem}}</span>"?</h1>
+      <h1>Rename <span>{{selectedType}}</span> "<span>{{selected}</span>"?</h1>
       <form>
         <paper-input id="renameInput" label="New Name" always-float-label></paper-input>
       </form>
@@ -308,7 +335,7 @@
     </paper-dialog>
 
     <paper-dialog id="deleteDialog" modal>
-      <h1>Delete <span>{{selectedType}}</span> "<span>{{selectedItem}}</span>"?</h1>
+      <h1>Delete <span>{{selectedType}}</span> "<span>{{selected}</span>"?</h1>
       <div class="buttons">
         <paper-button on-click="doDelete" dialog-confirm autofocus>OK</paper-button>
         <paper-button dialog-dismiss>CANCEL</paper-button>
@@ -321,6 +348,6 @@
 
     <paper-toast id="toastCopySuccess" text="Copy Successful!" duration=3000></paper-toast>
     <paper-toast id="toastMoveSuccess" text="Move Successful!" duration=3000></paper-toast>
-
+    </div>
   </template>
 </dom-module>

--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -196,23 +196,23 @@
         <paper-toolbar>
           <paper-button on-click="newKeyClicked">
             <iron-icon icon="create"></iron-icon>
-            new key
+            New Key
           </paper-button>
           <paper-button on-click="newFolderClicked">
             <iron-icon icon="folder-open"></iron-icon>
-            new dir
+            New Dir
           </paper-button>
           <paper-button on-click="copyClicked" disabled="[[!selected]]">
             <iron-icon icon="content-copy"></iron-icon>
-            copy
+            Copy
           </paper-button>
           <paper-button on-click="renameClicked" disabled="[[!selected]]">
             <iron-icon icon="code"></iron-icon>
-            rename
+            Rename
           </paper-button>
           <paper-button on-click="deleteClicked" disabled="[[!selected]]">
             <iron-icon icon="delete"></iron-icon>
-            delete
+            Delete
           </paper-button>
           <div id="search-bar">
             <paper-input id="search" value="{{filterText::input}}"
@@ -224,10 +224,10 @@
       </div>
       <div id="listing">
         <iron-list items="{{filteredListItems}}"
-                  id="combinedList"
-                  as="item"
-                  selected-item="{{selected}}"
-                  selection-enabled>
+                   id="combinedList"
+                   as="item"
+                   selected-item="{{selected}}"
+                   selection-enabled>
           <template>
             <div class$="row [[computeSelectedClass(selected)]]"
                 on-dblclick="editValueClicked"

--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -27,28 +27,29 @@
       width: 100%;
     }
 
+    #outer {
+      flex-direction: column;
+      position: relative;
+    }
+    #outer, #reg-area, #listing, #combinedList {
+      flex: 1;
+      display: flex;
+      width: 100%;
+    }
+    iron-list {
+      --iron-list-items-container: {
+        width: 100%;
+      };
+    }
+
+    .row {
+      cursor: pointer;
+      display: flex;
+      flex-direction: row;
+      align-items: middle;
+    }
     .row:nth-child(1n).iron-selected {
       background-color: #CCCCCC;
-    }
-
-    .iron-selector {
-      width: 100%;
-      display: block;
-      border: 1px solid #ccc;
-      border-top: none;
-    }
-
-    table {
-      width: 100%;
-      border-collapse: collapse;
-    }
-
-    tbody {
-      display:table-header-group;
-    }
-
-    td.dir.over {
-      background-color: #93d4d4;
     }
     .row:nth-child(odd) {
       background-color: #EEEEEE;
@@ -59,19 +60,36 @@
     .row:nth-child(even):hover {
       background-color: #FFFFAA;
     }
-
-    .table-header {
-      @apply(--paper-font-body1);
-      color: var(--secondary-text-color);
-      *text-align: middle;
-      border-bottom: 1px solid;
-      border-bottom-color: #e5e5e5;
-      display:table-header-group;
-
+    .row.dir.over {
+      background-color: #93d4d4;
     }
-    .label-wide {
+    .row .dir {
+      white-space: nowrap;
+      -webkit-user-select: none;
+    }
+    .row .key {
+      width: 400px;
+      white-space: nowrap;
+      padding-right: 2em;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .row .value {
+      flex: 1;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      padding-right: 1em;
+      line-height: 30px;
+    }
+
+    .iron-selector {
       width: 100%;
+      display: block;
+      border: 1px solid #ccc;
+      border-top: none;
     }
+
     paper-toolbar {
       background-color: #EEEEEE;
       color: black;
@@ -113,28 +131,14 @@
       font-family: 'roboto mono', monospace;
       font-size: 15px;
     }
-    td.dir {
-      white-space: nowrap;
-      -webkit-user-select: none;
-    }
-    td.key {
-      white-space: nowrap;
-      padding-right: 2em;
-    }
-    td.value {
-      max-width: 100px;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      padding-right: 1em;
-    }
+
     iron-icon {
       margin: 5px;
     }
     iron-icon.folder {
       color: #CFBA78;
     }
-    iron-icon.key {
+    .key iron-icon {
       color: #209131;
     }
     paper-dialog {
@@ -154,25 +158,6 @@
     .label-wide .back-link:hover,
     .label-wide .back-link:visited:hover {
       color: #3f51b5;
-    }
-    #outer {
-      display: flex;
-      flex-direction: column;
-      position: relative;
-      width: 100%;
-    }
-    #reg-area, #listing, #combinedList {
-      flex: 1;
-      display: flex;
-      width: 100%;
-    }
-    .row {
-      width: 100%;
-    }
-    iron-list {
-      --iron-list-items-container: {
-        width: 100%;
-      };
     }
   </style>
   <template>
@@ -222,7 +207,7 @@
                 <div class="key mono"
                     name="{{item.name}}"
                     draggable="true">
-                  <iron-icon icon="communication:vpn-key" item-icon class="key"></iron-icon>
+                  <iron-icon icon="communication:vpn-key" item-icon></iron-icon>
                   <span>{{item.name}}</span>
                 </div>
                 <div class="value label-wide mono">

--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -230,10 +230,10 @@
                    selection-enabled>
           <template>
             <div class$="row [[computeSelectedClass(selected)]]"
-                on-dblclick="editValueClicked"
-                name="{{item.name}}"
-                key-name="{{item.name}}"
-                is-key="{{item.isKey}}">
+                 on-dblclick="editValueClicked"
+                 name="{{item.name}}"
+                 key-name="{{item.name}}"
+                 is-key="{{item.isKey}}">
               <template is="dom-if" if="{{item.isParent}}">
                 <div class="label-wide">
                   <a class='back-link' is="app-link" path="{{item.url}}" href="{{item.url}}">
@@ -244,11 +244,11 @@
               </template>
               <template is="dom-if" if="{{item.isDir}}">
                 <div class="dir label-wide"
-                    name="{{item.name}}"
-                    draggable="true"
-                    on-dragover="onDirDragOver"
-                    on-dragleave="onDirDragLeave"
-                    on-drop="dirDrop">
+                     name="{{item.name}}"
+                     draggable="true"
+                     on-dragover="onDirDragOver"
+                     on-dragleave="onDirDragLeave"
+                     on-drop="dirDrop">
                   <a is="app-link" path="{{item.url}}" href="{{item.url}}">
                     <iron-icon icon="folder" item-icon class="folder"></iron-icon>
                     <span>{{item.name}}</span>
@@ -257,8 +257,8 @@
               </template>
               <template is="dom-if" if="{{item.isKey}}">
                 <div class="key mono"
-                      name="{{item.name}}"
-                    draggable="true">
+                     name="{{item.name}}"
+                     draggable="true">
                   <iron-icon icon="communication:vpn-key" item-icon></iron-icon>
                   <span>{{item.name}}</span>
                 </div>
@@ -284,7 +284,7 @@
     </paper-dialog>
 
     <paper-dialog id="editValueDialog" modal>
-      <h1>Edit <span>{{selected.name}}</span></h1>
+      <h1>Edit "<span>{{selected.name}}</span>"</h1>
       <paper-textarea id="editValueInput" label="Value" autofocus></paper-textarea>
       <div class="buttons">
         <paper-button on-tap="doEditValue" dialog-confirm>OK</paper-button>
@@ -302,7 +302,12 @@
     </paper-dialog>
 
      <paper-dialog id="dragDialog" modal>
-      <h1><span id="dragOp"></span> <span id="dragClass"></span> "<span id="originName"></span>" from <span id="originPath"></span></h1>
+      <h1>
+        <span id="dragOp"></span>
+        <span id="dragClass"></span>
+        "<span id="originName"></span>" from
+        <span id="originPath"></span>
+      </h1>
       <paper-input id="dragNameInput" label="New Name" always-float-label></paper-input>
       <paper-input id="dragPathInput" label="New Path" always-float-label></paper-input>
       <div class="buttons">

--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -178,6 +178,11 @@
   <template>
   <div id="outer">
     <div id="reg-area">
+      <!-- Dialog Controls -->
+      <iron-a11y-keys target="[[target]]" keys="esc"
+                      on-keys-pressed="dialogCancel"></iron-a11y-keys>
+      <iron-a11y-keys target="[[target]]" keys="shift+enter"
+                      on-keys-pressed="dialogSubmit"></iron-a11y-keys>
       <!-- Cursor Controls -->
       <iron-a11y-keys target="[[target]]" keys="up down"
                       on-keys-pressed="cursorMove"></iron-a11y-keys>
@@ -185,16 +190,11 @@
                       on-keys-pressed="cursorTraverse"></iron-a11y-keys>
       <iron-a11y-keys target="[[target]]" keys="left backspace"
                       on-keys-pressed="cursorBack"></iron-a11y-keys>
-      <!-- Dialog Controls -->
-      <iron-a11y-keys target="[[target]]" keys="esc"
-                      on-keys-pressed="dialogCancel"></iron-a11y-keys>
-      <iron-a11y-keys target="[[target]]" keys="shift+enter"
-                      on-keys-pressed="dialogSubmit"></iron-a11y-keys>
       <!-- Search Controls -->
       <iron-a11y-keys target="[[target]]" keys="enter"
                       on-keys-pressed="searchSubmit"></iron-a11y-keys>
       <div id="listing">
-        <iron-list items="[[filteredListItems]]"
+        <iron-list items="{{filteredListItems}}"
                   id="combinedList"
                   as="item"
                   selected-item="{{selected}}"

--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -288,7 +288,7 @@
     </paper-dialog>
 
     <paper-dialog id="editValueDialog" modal>
-      .NAME<h1>Edit <span>{{selected.name}}</span></h1>
+      <h1>Edit <span>{{selected.name}}</span></h1>
       <form>
         <paper-textarea id="editValueInput" label="Value" autofocus></paper-textarea>
       </form>

--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -60,7 +60,7 @@
     .row:nth-child(even):hover {
       background-color: #FFFFAA;
     }
-    .row.dir.over {
+    .row .dir.over {
       background-color: #93d4d4;
     }
     .row .dir {
@@ -160,6 +160,9 @@
       max-width: 90%;
       max-height: 90%;
     }
+    .label-wide {
+      width: 100%;
+    }
     .label-wide a {
       text-decoration: none;
     }
@@ -228,7 +231,7 @@
               </template>
               <template is="dom-if" if="{{item.isKey}}">
                 <div class="key mono"
-                    name="{{item.name}}"
+                      name="{{item.name}}"
                     draggable="true">
                   <iron-icon icon="communication:vpn-key" item-icon></iron-icon>
                   <span>{{item.name}}</span>

--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -100,6 +100,9 @@
       width: 300px;
       height: 300px;
     }
+    paper-button {
+      white-space: nowrap;
+    }
     menu-button {
       color: #0F9D58;
     }

--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -288,7 +288,7 @@
     </paper-dialog>
 
     <paper-dialog id="editValueDialog" modal>
-      <h1>Edit <span>{{selected}}</span></h1>
+      .NAME<h1>Edit <span>{{selected.name}}</span></h1>
       <form>
         <paper-textarea id="editValueInput" label="Value" autofocus></paper-textarea>
       </form>
@@ -322,7 +322,7 @@
     </paper-dialog>
 
     <paper-dialog id="copyDialog" modal>
-      <h1>Copy <span>{{selectedType}}</span> "<span>{{selected}}</span>"?</h1>
+      <h1>Copy <span>{{selectedType}}</span> "<span>{{selected.name}}</span>"?</h1>
       <form>
         <paper-input id="copyNameInput" label="New Name" always-float-label autofocus></paper-input>
         <paper-input id="copyPathInput" label="New Path" always-float-label></paper-input>
@@ -334,7 +334,7 @@
     </paper-dialog>
 
     <paper-dialog id="renameDialog" modal>
-      <h1>Rename <span>{{selectedType}}</span> "<span>{{selected}</span>"?</h1>
+      <h1>Rename <span>{{selectedType}}</span> "<span>{{selected.name}}</span>"?</h1>
       <form>
         <paper-input id="renameInput" label="New Name" always-float-label autofocus></paper-input>
       </form>
@@ -345,7 +345,7 @@
     </paper-dialog>
 
     <paper-dialog id="deleteDialog" modal>
-      <h1>Delete <span>{{selectedType}}</span> "<span>{{selected}</span>"?</h1>
+      <h1>Delete <span>{{selectedType}}</span> "<span>{{selected.name}}</span>"?</h1>
       <div class="buttons">
         <paper-button on-click="doDelete" dialog-confirm autofocus>OK</paper-button>
         <paper-button dialog-dismiss>CANCEL</paper-button>

--- a/client-js/app/elements/labrad-registry.html
+++ b/client-js/app/elements/labrad-registry.html
@@ -11,13 +11,6 @@
       display: flex;
     }
 
-    #reg-menu {
-      position: fixed;
-      top: var(--maintoolbar-height);
-      width: 100%;
-      @apply(--shadow-elevation-2dp);
-    }
-
     #reg-area {
       margin-top: var(--maintoolbar-height);
       background-color: white;
@@ -31,7 +24,7 @@
       flex-direction: column;
       position: relative;
     }
-    #outer, #reg-area, #listing, #combinedList {
+    #outer, #listing, #combinedList {
       flex: 1;
       display: flex;
       width: 100%;
@@ -180,22 +173,52 @@
   </style>
   <template>
   <div id="outer">
-    <div id="reg-area">
-      <!-- Dialog Controls -->
-      <iron-a11y-keys target="[[target]]" keys="esc"
-                      on-keys-pressed="dialogCancel"></iron-a11y-keys>
-      <iron-a11y-keys target="[[target]]" keys="shift+enter enter"
-                      on-keys-pressed="dialogSubmit"></iron-a11y-keys>
-      <!-- Cursor Controls -->
-      <iron-a11y-keys target="[[target]]" keys="up down"
-                      on-keys-pressed="cursorMove"></iron-a11y-keys>
-      <iron-a11y-keys target="[[target]]" keys="right enter"
-                      on-keys-pressed="cursorTraverse"></iron-a11y-keys>
-      <iron-a11y-keys target="[[target]]" keys="left backspace"
-                      on-keys-pressed="cursorBack"></iron-a11y-keys>
-      <!-- Search Controls -->
-      <iron-a11y-keys target="[[target]]" keys="enter"
-                      on-keys-pressed="searchSubmit"></iron-a11y-keys>
+    <!-- Dialog Controls -->
+    <iron-a11y-keys target="[[target]]" keys="esc"
+                    on-keys-pressed="dialogCancel"></iron-a11y-keys>
+    <iron-a11y-keys target="[[target]]" keys="shift+enter enter"
+                    on-keys-pressed="dialogSubmit"></iron-a11y-keys>
+    <!-- Cursor Controls -->
+    <iron-a11y-keys target="[[target]]" keys="up down"
+                    on-keys-pressed="cursorMove"></iron-a11y-keys>
+    <iron-a11y-keys target="[[target]]" keys="right enter"
+                    on-keys-pressed="cursorTraverse"></iron-a11y-keys>
+    <iron-a11y-keys target="[[target]]" keys="left backspace"
+                    on-keys-pressed="cursorBack"></iron-a11y-keys>
+    <!-- Search Controls -->
+    <iron-a11y-keys target="[[target]]" keys="enter"
+                    on-keys-pressed="searchSubmit"></iron-a11y-keys>
+    <paper-header-panel id="left-column">
+      <div class="paper-header" id="buttons">
+        <paper-toolbar>
+          <paper-button on-click="newKeyClicked">
+            <iron-icon icon="create"></iron-icon>
+            new key
+          </paper-button>
+          <paper-button on-click="newFolderClicked">
+            <iron-icon icon="folder-open"></iron-icon>
+            new dir
+          </paper-button>
+          <paper-button on-click="copyClicked" disabled="[[!selected]]">
+            <iron-icon icon="content-copy"></iron-icon>
+            copy
+          </paper-button>
+          <paper-button on-click="renameClicked" disabled="[[!selected]]">
+            <iron-icon icon="code"></iron-icon>
+            rename
+          </paper-button>
+          <paper-button on-click="deleteClicked" disabled="[[!selected]]">
+            <iron-icon icon="delete"></iron-icon>
+            delete
+          </paper-button>
+          <div id="search-bar">
+            <paper-input id="search" value="{{filterText::input}}"
+              noLabelFloat>
+              <iron-icon icon="search" prefix></iron-icon>
+            </paper-input>
+          </div>
+        </paper-toolbar>
+      </div>
       <div id="listing">
         <iron-list items="{{filteredListItems}}"
                   id="combinedList"
@@ -244,37 +267,6 @@
           </template>
         </iron-list>
       </div>
-    </div>
-    <div id="reg-menu">
-      <paper-toolbar>
-        <paper-button on-click="newKeyClicked">
-          <iron-icon icon="create"></iron-icon>
-          new key
-        </paper-button>
-        <paper-button on-click="newFolderClicked">
-          <iron-icon icon="folder-open"></iron-icon>
-          new dir
-        </paper-button>
-        <paper-button on-click="copyClicked" disabled="[[!selected]]">
-          <iron-icon icon="content-copy"></iron-icon>
-          copy
-        </paper-button>
-        <paper-button on-click="renameClicked" disabled="[[!selected]]">
-          <iron-icon icon="code"></iron-icon>
-          rename
-        </paper-button>
-        <paper-button on-click="deleteClicked" disabled="[[!selected]]">
-          <iron-icon icon="delete"></iron-icon>
-          delete
-        </paper-button>
-        <div id="search-bar">
-          <paper-input id="search" value="{{filterText::input}}"
-            noLabelFloat>
-            <iron-icon icon="search" prefix></iron-icon>
-          </paper-input>
-        </div>
-      </paper-toolbar>
-    </div>
 
     <!-- Dialogs for various registry operations -->
 

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -167,7 +167,7 @@ export class LabradRegistry extends polymer.Base {
       return;
     }
 
-    const item = this.$.combinedList.selectedItem;
+    const item = this.selected;
     if (!item) {
       return;
     }
@@ -540,7 +540,7 @@ export class LabradRegistry extends polymer.Base {
 
 
   private editValueSelected() {
-    const item = this.$.combinedList.selectedItem;
+    const item = this.selected;
     const dialog = this.$.editValueDialog;
     const editValueElem = this.$.editValueInput;
 
@@ -635,7 +635,7 @@ export class LabradRegistry extends polymer.Base {
     const dialog = this.$.copyDialog,
           copyNameElem = this.$.copyNameInput,
           copyPathElem = this.$.copyPathInput;
-    copyNameElem.value = this.$.combinedList.selectedItem.name;
+    copyNameElem.value = this.selected.name;
     copyPathElem.value = this.pathToString(this.path);
     dialog.open();
   }
@@ -647,7 +647,7 @@ export class LabradRegistry extends polymer.Base {
   async doCopy() {
     const newName = this.$.copyNameInput.value;
     const newPath = JSON.parse(this.$.copyPathInput.value);
-    const name = this.$.combinedList.selectedItem.name;
+    const name = this.selected.name;
 
     try {
       if (this.selected.isDir) {
@@ -730,7 +730,7 @@ export class LabradRegistry extends polymer.Base {
   renameClicked() {
     const dialog = this.$.renameDialog,
           renameElem = this.$.renameInput,
-          name = this.$.combinedList.selectedItem.name;
+          name = this.selected.name;
     renameElem.value = name;
     dialog.open();
   }
@@ -742,7 +742,7 @@ export class LabradRegistry extends polymer.Base {
     // TODO(maffoo) Add pending modal dialog for renames since they are copy
     // commands and take a long time.
     const newName = this.$.renameInput.value,
-          name = this.$.combinedList.selectedItem.name;
+          name = this.selected.name;
 
     if (newName === null || newName === name) {
       return;
@@ -782,9 +782,9 @@ export class LabradRegistry extends polymer.Base {
       if (this.selected.isDir) {
         this.$.pendingDialog.open();
         this.$.pendingOp.innerText = 'Deleting...';
-        await this.socket.rmDir({path: this.path, dir: this.$.combinedList.selectedItem.name});
+        await this.socket.rmDir({path: this.path, dir: this.selected.name});
       } else if (this.selected.isKey) {
-        await this.socket.del({path: this.path, key: this.$.combinedList.selectedItem.name});
+        await this.socket.del({path: this.path, key: this.selected.name});
       }
     } catch (error) {
       this.handleError(error);

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -110,6 +110,13 @@ export class LabradRegistry extends polymer.Base {
   }
 
 
+  /**
+   * Move the cursor on the currently selected item to the next item in the
+   * list depending on if up or down is pressed. If nothing is selected then
+   * the first item in the list is selected when down is pressed.
+   *
+   * This action doesn't work if a dialog is open.
+   */
   cursorMove(event) {
     if (this.getOpenDialog()) {
       return;
@@ -147,14 +154,20 @@ export class LabradRegistry extends polymer.Base {
   }
 
 
+  /**
+   * If we have a selected item, we want to follow it. In the case of a
+   * directory, this means going into it. In the case of a key, it means
+   * opening the edit box.
+   *
+   * This action doesn't work if a dialog window is open or if the search box
+   * is focused.
+   */
   cursorTraverse(event) {
     if (this.getSelectedIndex() === null || this.getOpenDialog() || this.$.search.focused) {
       return;
     }
 
     const item = this.$.combinedList.selectedItem;
-
-    // If we have an item, we want to traverse down.
     if (!item) {
       return;
     }
@@ -168,6 +181,13 @@ export class LabradRegistry extends polymer.Base {
   }
 
 
+  /**
+   * Traverse back up the directory tree if we aren't already at the registry
+   * root.
+   *
+   * This action doesn't work if there is an open dialog or the search box is
+   * focused.
+   */
   cursorBack(event) {
     if (this.path.length === 0 || this.getOpenDialog() || this.$.search.focused) {
       return;

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -73,7 +73,8 @@ export class LabradRegistry extends polymer.Base {
 
 
   private getDefaultSelectedItem(): number {
-    return this.getListOffset();
+    const offset = this.getListOffset();
+    return (this.filteredListItems.length > 1) ? offset : 0;
   }
 
 
@@ -191,6 +192,14 @@ export class LabradRegistry extends polymer.Base {
       return;
     }
 
+    // New keys have a textbox, so we only want to submit on Shift+Enter,
+    // not on a solo enter keypress.
+    if (event.detail.combo !== "shift+enter") {
+      if (dialog.id == 'newKeyDialog' || dialog.id === 'editValueDialog') {
+        return;
+      }
+    }
+
     event.detail.keyboardEvent.preventDefault();
 
     switch (dialog.id) {
@@ -198,12 +207,12 @@ export class LabradRegistry extends polymer.Base {
         this.doNewKey();
         break;
 
-      case 'newFolderDialog':
-        this.doNewFolder();
-        break;
-
       case 'editValueDialog':
         this.doEditValue();
+        break;
+
+      case 'newFolderDialog':
+        this.doNewFolder();
         break;
 
       case 'renameDialog':

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -348,7 +348,9 @@ export class LabradRegistry extends polymer.Base {
     }
 
     const selected = this.selected;
+    const selectedIndex = this.getSelectedIndex();
     this.applyFilterToListItems();
+    const listLength = this.filteredListItems.length;
 
     let index = this.getDefaultSelectedItem();
 
@@ -358,11 +360,30 @@ export class LabradRegistry extends polymer.Base {
     // the same. This handles both the case of renaming a dir/key or changing
     // the value of it.
     if (selected) {
-      for (let i = 0; i < this.filteredListItems.length; ++i) {
+      index = -1;
+      for (let i = 0; i < listLength; ++i) {
         const item = this.filteredListItems[i];
-        if (item.name == selected.name || item.value == selected.value) {
+        if ((item.name === selected.name || item.value === selected.value) &&
+            (item.isDir === selected.isDir && item.isKey === selected.isKey)) {
           index = i;
-          break;
+          // If we've matched on name, we're confident to stop.
+          if (item.name === selected.name) {
+            break;
+          }
+        }
+      }
+
+      if (index === -1) {
+        // We've deleted the last item in the list, place cursor at the end.
+        if (selectedIndex === listLength) {
+          index = listLength - 1;
+        }
+
+        // Place the cursor back where it was if that position is still valid.
+        // Note, selected index should never be greater than listLength since
+        // only one element can be deleted at a time.
+        else {
+          index = selectedIndex;
         }
       }
     }
@@ -750,6 +771,7 @@ export class LabradRegistry extends polymer.Base {
     }
 
     if (!newName) {
+      const selectedType = (this.selected.isDir) ? "dir" : "key";
       this.handleError(`Cannot rename ${selectedType} to empty string`);
       return;
     }

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -413,33 +413,12 @@ export class LabradRegistry extends polymer.Base {
 
 
   /**
-   * Drag and drop logic.
-   */
-  @listen('dragenter')
-  onDragEnter(event) {
-    event.preventDefault();
-  }
-
-
-  @listen('dragleave')
-  onDragLeave(event) {
-    event.preventDefault();
-  }
-
-
-  /**
    * Allows the ctrl key to be pressed to change cursor between copy/move.
    */
   @listen('dragover')
   onDragOver(event) {
     event.preventDefault();
-
-    if (event.ctrlKey) {
-      event.dataTransfer.dropEffect = 'copy';
-    }
-    else {
-      event.dataTransfer.dropEffect = 'move';
-    }
+    event.dataTransfer.dropEffect = (event.ctrlKey) ? 'copy' : 'move';
   }
 
 
@@ -464,10 +443,6 @@ export class LabradRegistry extends polymer.Base {
   onDirDragLeave(event) {
     event.currentTarget.classList.remove('over');
   }
-
-
-  @listen('dragend')
-  endDrag(event) {}
 
 
   /**

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -212,10 +212,10 @@ export class LabradRegistry extends polymer.Base {
       return;
     }
 
-    // New keys have a textbox, so we only want to submit on Shift+Enter,
+    // For dialogs with a textbox, so we only want to submit on Shift+Enter,
     // not on a solo enter keypress.
-    if (event.detail.combo !== 'shift+enter') {
-      if (dialog.id == 'newKeyDialog' || dialog.id === 'editValueDialog') {
+    if (dialog.id == 'newKeyDialog' || dialog.id === 'editValueDialog') {
+      if (event.detail.combo !== 'shift+enter') {
         return;
       }
     }
@@ -660,11 +660,10 @@ export class LabradRegistry extends polymer.Base {
     const newName = this.$.copyNameInput.value;
     const newPath = JSON.parse(this.$.copyPathInput.value);
 
-    const selectedType = this.getSelectedType();
     const name = this.$.combinedList.selectedItem.name;
 
     try {
-      if (selectedType === 'dir') {
+      if (this.selected.isDir) {
         this.$.pendingDialog.open();
         this.$.pendingOp.innerText = 'Copying...';
         await this.socket.copyDir({
@@ -673,8 +672,7 @@ export class LabradRegistry extends polymer.Base {
           newPath: newPath,
           newDir: newName
         });
-      }
-      else if (selectedType === 'key') {
+      } else if (this.selected.isKey) {
         await this.socket.copy({
           path: this.path,
           key: name,

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -194,7 +194,7 @@ export class LabradRegistry extends polymer.Base {
 
     // New keys have a textbox, so we only want to submit on Shift+Enter,
     // not on a solo enter keypress.
-    if (event.detail.combo !== "shift+enter") {
+    if (event.detail.combo !== 'shift+enter') {
       if (dialog.id == 'newKeyDialog' || dialog.id === 'editValueDialog') {
         return;
       }
@@ -369,7 +369,7 @@ export class LabradRegistry extends polymer.Base {
 
 
   computeSelectedClass(selected: ListItem): string {
-    return (selected) ? "iron-selected" : "";
+    return (selected) ? 'iron-selected' : '';
   }
 
 
@@ -380,61 +380,68 @@ export class LabradRegistry extends polymer.Base {
 
 
   /**
-   * Drag and drop logic
+   * Drag and drop logic.
    */
   @listen('dragenter')
   onDragEnter(event) {
-    event.preventDefault(); //I don't understand this.
+    event.preventDefault();
   }
+
 
   @listen('dragleave')
   onDragLeave(event) {
-    event.preventDefault(); //I don't understand this. But it needs to be here
+    event.preventDefault();
   }
 
+
   /**
-   * allows the ctrl key to be pressed to change cursor between copy/move
+   * Allows the ctrl key to be pressed to change cursor between copy/move.
    */
   @listen('dragover')
   onDragOver(event) {
-    event.preventDefault(); //I don't understand this. But needs to be here
+    event.preventDefault();
+
     if (event.ctrlKey) {
-      event.dataTransfer.dropEffect = "copy";
+      event.dataTransfer.dropEffect = 'copy';
     }
     else {
-      event.dataTransfer.dropEffect = "move";
+      event.dataTransfer.dropEffect = 'move';
     }
   }
 
+
   @listen('dragstart')
   startDrag(event) {
-    //detect start of drag event, grab info about target
-    var data: any; //I tried enum, but kept getting errors...
+    // Detect start of drag event, grab info about target.
+    const data: any; //I tried enum, but kept getting errors...
     data = {path: this.path, name: event.target.name, kind: event.target.className.split(' ')[0]};
     event.dataTransfer.setData('text', JSON.stringify(data));
     event.dataTransfer.effectAllowed = 'copyMove';
   }
 
+
   onDirDragOver(event) {
     event.currentTarget.classList.add('over');
   }
+
 
   onDirDragLeave(event) {
     event.currentTarget.classList.remove('over');
   }
 
+
   @listen('dragend')
-  endDrag(event) {
-  }
+  endDrag(event) {}
+
 
   /**
-   * behaviour for dropping on folders
+   * Behaviour for dropping on folders.
    */
   dirDrop(event) {
     event.stopPropagation();
-    var data = JSON.parse(event.dataTransfer.getData('text'));
+    const data = JSON.parse(event.dataTransfer.getData('text'));
     this.$.dragDialog.dragData = data;
-    var newPath: string[] = this.path.slice();
+    const newPath: string[] = this.path.slice();
     newPath.push(event.target.closest('td').name);
     event.target.closest('td').classList.remove('over');
     this.$.dragNameInput.value = data.name;
@@ -462,7 +469,7 @@ export class LabradRegistry extends polymer.Base {
   @listen('drop')
   handleDrop(event) {
     event.preventDefault();
-    var data = JSON.parse(event.dataTransfer.getData('text'));
+    const data = JSON.parse(event.dataTransfer.getData('text'));
     this.$.dragDialog.dragData = data;
     event.target.closest('td').classList.remove('over');
     this.$.dragNameInput.value = data.name;
@@ -493,7 +500,7 @@ export class LabradRegistry extends polymer.Base {
   bindIronAutogrowTextAreaResizeEvents(paperDialog: HTMLElement,
                                        ironAutogrowTextarea: HTMLElement) {
     ironAutogrowTextarea.addEventListener('bind-value-changed', () => {
-      Polymer.Base.fire("iron-resize", null, {node: ironAutogrowTextarea});
+      Polymer.Base.fire('iron-resize', null, {node: ironAutogrowTextarea});
     });
   }
 
@@ -501,9 +508,9 @@ export class LabradRegistry extends polymer.Base {
    * Launch new key dialog.
    */
   newKeyClicked(event) {
-    var dialog = this.$.newKeyDialog,
-        newKeyElem = this.$.newKeyInput,
-        newValueElem = this.$.newValueInput;
+    const dialog = this.$.newKeyDialog,
+          newKeyElem = this.$.newKeyInput,
+          newValueElem = this.$.newValueInput;
     newKeyElem.value = '';
     newValueElem.value = '';
     dialog.open();
@@ -513,8 +520,8 @@ export class LabradRegistry extends polymer.Base {
    * Create new key.
    */
   async doNewKey() {
-    var newKey = this.$.newKeyInput.value;
-    var newVal = this.$.newValueInput.value;
+    const newKey = this.$.newKeyInput.value;
+    const newVal = this.$.newValueInput.value;
 
     if (newKey) {
       try {
@@ -544,12 +551,12 @@ export class LabradRegistry extends polymer.Base {
    * Launch the value edit dialog.
    */
   editValueClicked(event) {
-    var dialog = this.$.editValueDialog,
-        editValueElem = this.$.editValueInput,
-        name = event.currentTarget.keyName,
-        isKey = event.currentTarget.isKey,
-        value: string = null,
-        found = false;
+    const dialog = this.$.editValueDialog,
+          editValueElem = this.$.editValueInput,
+          name = event.currentTarget.keyName,
+          isKey = event.currentTarget.isKey,
+          value: string = null,
+          found = false;
     if (!isKey) return;
     for (let item of this.keys) {
       if (item.name == name) {
@@ -571,8 +578,8 @@ export class LabradRegistry extends polymer.Base {
    * Submit the edited value to the server.
    */
   async doEditValue() {
-    var key = this.$.editValueDialog.keyName,
-        newVal = this.$.editValueInput.value;
+    const key = this.$.editValueDialog.keyName,
+          newVal = this.$.editValueInput.value;
     try {
       await this.socket.set({path: this.path, key: key, value: newVal});
     } catch (error) {
@@ -584,8 +591,8 @@ export class LabradRegistry extends polymer.Base {
    * Launch new folder dialog.
    */
   newFolderClicked() {
-    var dialog = this.$.newFolderDialog,
-        newFolderElem = this.$.newFolderInput;
+    const dialog = this.$.newFolderDialog,
+          newFolderElem = this.$.newFolderInput;
     newFolderElem.value = '';
     dialog.open();
   }
@@ -634,7 +641,7 @@ export class LabradRegistry extends polymer.Base {
     try {
       if (selectedType === 'dir') {
         this.$.pendingDialog.open();
-        this.$.pendingOp.innerText = "Copying...";
+        this.$.pendingOp.innerText = 'Copying...';
         await this.socket.copyDir({
           path: this.path,
           dir: name,
@@ -659,22 +666,22 @@ export class LabradRegistry extends polymer.Base {
    * Execute the drag operation
    */
   async doDragOp() {
-    var newName =  this.$.dragNameInput.value;
-    var newPath = JSON.parse(this.$.dragPathInput.value);
-    var oldPath = JSON.parse(this.$.originPath.textContent);
-    var oldName = this.$.originName.textContent;
+    const newName =  this.$.dragNameInput.value;
+    const newPath = JSON.parse(this.$.dragPathInput.value);
+    const oldPath = JSON.parse(this.$.originPath.textContent);
+    const oldName = this.$.originName.textContent;
 
     if (this.$.dragOp.innerText === 'Copy') {
       try {
         this.$.pendingDialog.open();
-        this.$.pendingOp.innerText = "Copying...";
+        this.$.pendingOp.innerText = 'Copying...';
         switch (this.$.dragDialog.dragData['kind']) {
-          case "dir":
-            var resp = await this.socket.copyDir({path: oldPath, dir: oldName, newPath: newPath, newDir: newName});
+          case 'dir':
+            const resp = await this.socket.copyDir({path: oldPath, dir: oldName, newPath: newPath, newDir: newName});
             break;
 
-          case "key":
-            var resp = await this.socket.copy({path: oldPath, key: oldName, newPath: newPath, newKey: newName});
+          case 'key':
+            const resp = await this.socket.copy({path: oldPath, key: oldName, newPath: newPath, newKey: newName});
             break;
         }
       } catch (error) {
@@ -687,14 +694,14 @@ export class LabradRegistry extends polymer.Base {
     else if (this.$.dragOp.innerText === 'Move') {
       try {
         this.$.pendingDialog.open();
-        this.$.pendingOp.innerText = "Moving...";
+        this.$.pendingOp.innerText = 'Moving...';
         switch (this.$.dragDialog.dragData['kind']) {
-          case "dir":
-            var resp = await this.socket.moveDir({path: oldPath, dir: oldName, newPath: newPath, newDir: newName});
+          case 'dir':
+            const resp = await this.socket.moveDir({path: oldPath, dir: oldName, newPath: newPath, newDir: newName});
             break;
 
-          case "key":
-            var resp = await this.socket.move({path: oldPath, key: oldName, newPath: newPath, newKey: newName});
+          case 'key':
+            const resp = await this.socket.move({path: oldPath, key: oldName, newPath: newPath, newKey: newName});
             break;
         }
       } catch (error) {
@@ -767,7 +774,7 @@ export class LabradRegistry extends polymer.Base {
       const selectedType = this.getSelectedType();
       if (selectedType === 'dir') {
         this.$.pendingDialog.open();
-        this.$.pendingOp.innerText = "Deleting...";
+        this.$.pendingOp.innerText = 'Deleting...';
         await this.socket.rmDir({path: this.path, dir: this.$.combinedList.selectedItem.name});
       }
       else if (selectedType === 'key') {

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -354,20 +354,23 @@ export class LabradRegistry extends polymer.Base {
 
     let index = this.getDefaultSelectedItem();
 
-    // If there was a previously selected item, say we were editing one, then
+    // If there was a previously selected key, say we were editing one, then
     // we want to reselect it after the list is repopulated. To do this we
     // fuzzy match the objects by requiring either the name or the value to be
-    // the same. This handles both the case of renaming a dir/key or changing
-    // the value of it.
+    // the same.
     if (selected) {
       index = -1;
       for (let i = 0; i < listLength; ++i) {
         const item = this.filteredListItems[i];
-        if ((item.name === selected.name || item.value === selected.value) &&
-            (item.isDir === selected.isDir && item.isKey === selected.isKey)) {
+        const namesMatch = (item.name === selected.name);
+        const valuesMatch = (item.value && (item.value === selected.value));
+        const dirsMatch = (item.isDir === selected.isDir);
+        const keysMatch = (item.isKey === selected.isKey);
+
+        if ((namesMatch || valuesMatch) && dirsMatch && keysMatch) {
           index = i;
           // If we've matched on name, we're confident to stop.
-          if (item.name === selected.name) {
+          if (namesMatch) {
             break;
           }
         }

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -154,14 +154,20 @@ export class LabradRegistry extends polymer.Base {
     this.set('filterText', '');
   }
 
-
   /**
    * triggers re-render of dir, key lists when filterText is changed
    */
   @observe('filterText')
   reloadMenu() {
+    if (!this.listItems) {
+      return;
+    }
+
     this.regex = new RegExp(this.filterText, 'i');
-    //this.$.fullList.render();
+    this.set('filteredListItems', this.listItems.filter((item) => {
+      console.log(!!item.name.match(this.regex), item);
+      return (!!item.name.match(this.regex));
+    }));
   }
 
 
@@ -226,6 +232,7 @@ export class LabradRegistry extends polymer.Base {
       });
     }
 
+    this.set('filteredListItems', this.listItems);
     this.$.combinedList.selectItem(this.getDefaultSelectedItem());
     this.$.pendingDialog.close()
   }

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -463,6 +463,7 @@ export class LabradRegistry extends polymer.Base {
 
   }
 
+
   /**
    * handles folders dropped not into folders
    */
@@ -489,6 +490,7 @@ export class LabradRegistry extends polymer.Base {
     }
   }
 
+
   /**
    * Bind event listeners to resize dialog box appropriately when an
    * `iron-autogrow-textarea` is used.
@@ -504,6 +506,7 @@ export class LabradRegistry extends polymer.Base {
     });
   }
 
+
   /**
    * Launch new key dialog.
    */
@@ -515,6 +518,7 @@ export class LabradRegistry extends polymer.Base {
     newValueElem.value = '';
     dialog.open();
   }
+
 
   /**
    * Create new key.
@@ -587,6 +591,7 @@ export class LabradRegistry extends polymer.Base {
     }
   }
 
+
   /**
    * Launch new folder dialog.
    */
@@ -596,6 +601,7 @@ export class LabradRegistry extends polymer.Base {
     newFolderElem.value = '';
     dialog.open();
   }
+
 
   /**
    * Create new folder.
@@ -627,6 +633,7 @@ export class LabradRegistry extends polymer.Base {
     copyPathElem.value = this.pathToString(this.path);
     dialog.open();
   }
+
 
   /**
    * Copy the selected key or folder.
@@ -662,8 +669,9 @@ export class LabradRegistry extends polymer.Base {
     }
   }
 
+
   /**
-   * Execute the drag operation
+   * Execute the drag operation.
    */
   async doDragOp() {
     const newName =  this.$.dragNameInput.value;
@@ -690,8 +698,7 @@ export class LabradRegistry extends polymer.Base {
         this.$.pendingDialog.close();
         this.$.toastCopySuccess.show();
       }
-    }
-    else if (this.$.dragOp.innerText === 'Move') {
+    } else if (this.$.dragOp.innerText === 'Move') {
       try {
         this.$.pendingDialog.open();
         this.$.pendingOp.innerText = 'Moving...';
@@ -719,11 +726,9 @@ export class LabradRegistry extends polymer.Base {
    */
   renameClicked() {
     const dialog = this.$.renameDialog,
-          renameElem = this.$.renameInput;
-
-    const item = this.$.combinedList.selectedItem;
-
-    renameElem.value = item.name;
+          renameElem = this.$.renameInput,
+          name = this.$.combinedList.selectedItem.name;
+    renameElem.value = name;
     dialog.open();
   }
 
@@ -733,31 +738,31 @@ export class LabradRegistry extends polymer.Base {
   async doRename() {
     // TODO(maffoo) Add pending modal dialog for renames since they are copy
     // commands and take a long time.
-    const newName = this.$.renameInput.value;
+    const newName = this.$.renameInput.value,
+          name = this.$.combinedList.selectedItem.name,
+          selectedType = this.getSelectedType();
 
-    const item = this.$.combinedList.selectedItem;
-    const name = item.name;
-
-    if (newName === null || newName === name) return;
-
-    const selectedType = this.getSelectedType();
-
-    if (newName) {
-      try {
-        if (selectedType === 'dir') {
-          await this.socket.renameDir({path: this.path, dir: name, newDir: newName});
-        }
-        else if (selectedType === 'key') {
-          await this.socket.rename({path: this.path, key: name, newKey: newName});
-        }
-      } catch (error) {
-        this.handleError(error);
-      }
+    if (newName === null || newName === name) {
+      return;
     }
-    else {
+
+    if (!newName) {
       this.handleError(`Cannot rename ${selectedType} to empty string`);
+      return;
+    }
+
+    try {
+      if (selectedType === 'dir') {
+        await this.socket.renameDir({path: this.path, dir: name, newDir: newName});
+      }
+      else if (selectedType === 'key') {
+        await this.socket.rename({path: this.path, key: name, newKey: newName});
+      }
+    } catch (error) {
+      this.handleError(error);
     }
   }
+
 
   /**
    * Launch the delete confirmation dialog.
@@ -765,6 +770,7 @@ export class LabradRegistry extends polymer.Base {
   deleteClicked() {
     this.$.deleteDialog.open();
   }
+
 
   /**
    * Delete the selected key or folder.
@@ -776,8 +782,7 @@ export class LabradRegistry extends polymer.Base {
         this.$.pendingDialog.open();
         this.$.pendingOp.innerText = 'Deleting...';
         await this.socket.rmDir({path: this.path, dir: this.$.combinedList.selectedItem.name});
-      }
-      else if (selectedType === 'key') {
+      } else if (selectedType === 'key') {
         await this.socket.del({path: this.path, key: this.$.combinedList.selectedItem.name});
       }
     } catch (error) {

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -40,9 +40,6 @@ export class LabradRegistry extends polymer.Base {
   @property({type: String, notify: true})
   notify: string;
 
-  @property({type: Number, value: 0})
-  kick: number;
-
   @property({type: String, notify: true, value: ''})
   filterText: string;
 

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -294,17 +294,6 @@ export class LabradRegistry extends polymer.Base {
   }
 
 
-  private getSelectedType(): string {
-    // Account for parent '..' entry.
-    const offset = this.getListOffset();
-    if (this.dirs && this.getSelectedIndex() < this.dirs.length + offset) {
-      return 'dir';
-    } else {
-      return 'key';
-    }
-  }
-
-
   /**
    * This is called whenever a newItem is added, hooked in actitives.
    */
@@ -659,7 +648,6 @@ export class LabradRegistry extends polymer.Base {
   async doCopy() {
     const newName = this.$.copyNameInput.value;
     const newPath = JSON.parse(this.$.copyPathInput.value);
-
     const name = this.$.combinedList.selectedItem.name;
 
     try {
@@ -755,8 +743,7 @@ export class LabradRegistry extends polymer.Base {
     // TODO(maffoo) Add pending modal dialog for renames since they are copy
     // commands and take a long time.
     const newName = this.$.renameInput.value,
-          name = this.$.combinedList.selectedItem.name,
-          selectedType = this.getSelectedType();
+          name = this.$.combinedList.selectedItem.name;
 
     if (newName === null || newName === name) {
       return;
@@ -768,10 +755,9 @@ export class LabradRegistry extends polymer.Base {
     }
 
     try {
-      if (selectedType === 'dir') {
+      if (this.selected.isDir) {
         await this.socket.renameDir({path: this.path, dir: name, newDir: newName});
-      }
-      else if (selectedType === 'key') {
+      } else if (this.selected.isKey) {
         await this.socket.rename({path: this.path, key: name, newKey: newName});
       }
     } catch (error) {
@@ -793,12 +779,11 @@ export class LabradRegistry extends polymer.Base {
    */
   async doDelete() {
     try {
-      const selectedType = this.getSelectedType();
-      if (selectedType === 'dir') {
+      if (this.selected.isDir) {
         this.$.pendingDialog.open();
         this.$.pendingOp.innerText = 'Deleting...';
         await this.socket.rmDir({path: this.path, dir: this.$.combinedList.selectedItem.name});
-      } else if (selectedType === 'key') {
+      } else if (this.selected.isKey) {
         await this.socket.del({path: this.path, key: this.$.combinedList.selectedItem.name});
       }
     } catch (error) {

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -514,8 +514,8 @@ export class LabradRegistry extends polymer.Base {
     const dialog = this.$.editValueDialog;
     const editValueElem = this.$.editValueInput;
 
-    editValueElem.value = item.keyValue;
-    dialog.keyName = item.keyName;
+    editValueElem.value = item.value;
+    dialog.keyName = item.name;
     dialog.open();
   }
 


### PR DESCRIPTION
Implements #278. Updated/Refactored the Registry to use an `iron-list` instead of a `table` with `dom-repeat`. This allows for smooth scrolling on the registry when using keyboard controls.

This also refactored the code to get rid of all computed properties, as well as the last instance of the `kick` hack. Also fixed problems with submitting forms via hitting enter in text fields, or while OK is selected. In addition, various style guide compliance changes.
