### PR TITLE
Fix rendering issue with breadcrumbs.

### DIFF
--- a/client-js/app/elements/labrad-app.html
+++ b/client-js/app/elements/labrad-app.html
@@ -62,8 +62,6 @@
     #location {
       white-space: nowrap;
       text-overflow: ellipsis;
-      overflow: hidden;
-      direction: rtl;
     }
 
     #tech-info {

--- a/client-js/app/elements/labrad-app.html
+++ b/client-js/app/elements/labrad-app.html
@@ -62,6 +62,11 @@
     #location {
       white-space: nowrap;
       text-overflow: ellipsis;
+      overflow: hidden;
+      direction: rtl;
+    }
+    #location labrad-breadcrumbs {
+      display: inline;
     }
 
     #tech-info {
@@ -136,7 +141,7 @@
               <span>{{route}}</span>
             </template>
             <template is="dom-if" if="{{hasBreadcrumbs}}">
-              <labrad-breadcrumbs breadcrumbs={{breadcrumbs}} extras={{breadcrumbExtras}} style="display: inline"></labrad-breadcrumbs>
+              <labrad-breadcrumbs breadcrumbs={{breadcrumbs}} extras={{breadcrumbExtras}}></labrad-breadcrumbs>
             </template>
           </div>
 

--- a/client-js/app/elements/labrad-app.html
+++ b/client-js/app/elements/labrad-app.html
@@ -63,7 +63,9 @@
       white-space: nowrap;
       text-overflow: ellipsis;
       overflow: hidden;
-      direction: rtl;
+    }
+    #locationInner {
+      float: right;
     }
     #location labrad-breadcrumbs {
       display: inline;
@@ -136,13 +138,16 @@
           </button>
 
           <!-- Application name -->
-          <div id="location">Labrad -
-            <template is="dom-if" if="{{!hasBreadcrumbs}}">
-              <span>{{route}}</span>
-            </template>
-            <template is="dom-if" if="{{hasBreadcrumbs}}">
-              <labrad-breadcrumbs breadcrumbs={{breadcrumbs}} extras={{breadcrumbExtras}}></labrad-breadcrumbs>
-            </template>
+          <div id="location">
+            <div id="locationInner">
+              <span>Labrad -</span>
+              <template is="dom-if" if="{{!hasBreadcrumbs}}">
+                <span>{{route}}</span>
+              </template>
+              <template is="dom-if" if="{{hasBreadcrumbs}}">
+                <labrad-breadcrumbs breadcrumbs={{breadcrumbs}} extras={{breadcrumbExtras}}></labrad-breadcrumbs>
+              </template>
+            </div>
           </div>
 
           <span class="flex"></span>


### PR DESCRIPTION
If you had a directory trailing underscores, like `default__` this would cause a really weird display error, where the trailing underscores moved to the start of the line before `Labrad`.

This fixes that.

![screenshot from 2016-08-10 17 47 00](https://cloud.githubusercontent.com/assets/153444/17575913/770b2d0a-5f22-11e6-9e8e-c6ec8918274d.png)
