### PR TITLE
Change grapher filter logic to match delphi version.

### DIFF
--- a/client-js/app/elements/labrad-grapher.ts
+++ b/client-js/app/elements/labrad-grapher.ts
@@ -294,12 +294,12 @@ export class LabradGrapher extends polymer.Base {
   }
 
   private filterListItemsFunction(): ListItemFilterFunction {
-    // Return trashed and parent items
+    // Return all items including those that are trashed.
     if (this.showTrash) {
-      return (x) => (x.trashed || x.isParent);
+      return (x) => true;
     }
 
-    // Return starred and parent items, no trash
+    // Return starred and parent items, no trash.
     if (this.showStars) {
       return (x) => ((x.starred && !x.trashed) || x.isParent);
     }


### PR DESCRIPTION
The star and trash buttons work differently in the delphi version; star limits the displayed list to _only_ starred items, while trash shows trashed items which are normally hidden in addition to the rest of the items. This changes the filter functions to match that behavior.
