### PR TITLE
Only run keyboard action handlers if no modifiers are pressed.

### DIFF
--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -223,7 +223,15 @@ export class LabradRegistry extends polymer.Base {
       return;
     }
 
-    const key = event.detail.combo;
+    const key = event.detail.combo,
+          keyboardEvent = event.detail.keyboardEvent,
+          hasModifiers = (keyboardEvent.shiftKey || keyboardEvent.ctrlKey ||
+                          keyboardEvent.altKey || keyboardEvent.metaKey);
+
+    if (hasModifiers) {
+      return;
+    }
+
     // Copy, Rename and Delete only work with a selection.
     if (!this.selected && (key === "c" || key === "d" || key === "r")) {
       return;


### PR DESCRIPTION
Even though we register the key handlers for bare keys `c`, `f`, etc, they seem to fire when pressed with modifiers, at least on mac, so that for example pressing `Cmd+f` focuses the registry filter box and prevents the browser's find-on-page box from opening. Similarly, pressing `Cmd+r` to reload the page pops up a rename dialog before then actually reloading the page. We fix this by checking that the key event has no modifiers before dispatching to the appropriate action. See https://github.com/PolymerElements/iron-a11y-keys-behavior/issues/41.
