### PR TITLE
Fix selection going offscreen for some window sizes.

### DIFF
--- a/client-js/app/elements/labrad-grapher.ts
+++ b/client-js/app/elements/labrad-grapher.ts
@@ -88,8 +88,8 @@ export class LabradGrapher extends polymer.Base {
 
     if (index < first) {
       list.scrollToIndex(index);
-    } else if (index > last) {
-      list.scrollToIndex(index - (last - first));
+    } else if (index >= last) {
+      list.scrollToIndex(index - (last - first - 1));
     }
   }
 

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -109,8 +109,8 @@ export class LabradRegistry extends polymer.Base {
 
     if (index < first) {
       list.scrollToIndex(index);
-    } else if (index > last) {
-      list.scrollToIndex(index - (last - first));
+    } else if (index >= last) {
+      list.scrollToIndex(index - (last - first - 1));
     }
   }
 


### PR DESCRIPTION
If the window is sized such that the last list element is only partially visible, that last element is included in polymer's `lastVisibleIndex` count. This happens even if only a few pixels are visible, in which case we cannot see the text and the selection appears to go offscreen. By offsetting, we ensure that the view scrolls to keep the selection on a fully-visible item. If the window size happens to be such that the final element just fits in the view, this scrolls one step earlier than it needs to, but I think keeping the selected item fully visible is more important.
