### PR TITLE
Fix item visibility on Registry and Grapher at certain window sizes.

### DIFF
--- a/client-js/app/elements/labrad-grapher.ts
+++ b/client-js/app/elements/labrad-grapher.ts
@@ -81,16 +81,32 @@ export class LabradGrapher extends polymer.Base {
   }
 
 
-  scrollToIndex(index: number) {
+  private scrollToIndex(index: number): void {
     const list = this.$.combinedList;
     const first = list.firstVisibleIndex;
     const last = list.lastVisibleIndex;
 
-    if (index < first) {
-      list.scrollToIndex(index);
-    } else if (index > last) {
-      list.scrollToIndex(index - (last - first));
+    // If between the first and last elements, no need to scroll.
+    if (index > first && index < last) {
+      return;
     }
+
+    const currentScroll = list.scrollTop;
+    const listBounds = list.getBoundingClientRect();
+    const selectedElement = list.children.items.querySelector('.iron-selected');
+    const selectedBounds = selectedElement.getBoundingClientRect();
+
+    // Due to the fact an element can be only partially on the screen, we want
+    // to scroll by the distance between the top/bottom of the element and the
+    // top/bottom of the list respectively, rather than a fixed amount or to a
+    // specific index.
+    let distance;
+    if (selectedBounds.top < listBounds.top) {
+      distance = selectedBounds.top - listBounds.top;
+    } else {
+      distance = selectedBounds.bottom - listBounds.bottom;
+    }
+    list.scroll(0, currentScroll + distance);
   }
 
 

--- a/client-js/app/elements/labrad-registry.ts
+++ b/client-js/app/elements/labrad-registry.ts
@@ -107,11 +107,27 @@ export class LabradRegistry extends polymer.Base {
     const first = list.firstVisibleIndex;
     const last = list.lastVisibleIndex;
 
-    if (index < first) {
-      list.scrollToIndex(index);
-    } else if (index > last) {
-      list.scrollToIndex(index - (last - first));
+    // If between the first and last elements, no need to scroll.
+    if (index > first && index < last) {
+      return;
     }
+
+    const currentScroll = list.scrollTop;
+    const listBounds = list.getBoundingClientRect();
+    const selectedElement = list.children.items.querySelector('.iron-selected');
+    const selectedBounds = selectedElement.getBoundingClientRect();
+
+    // Due to the fact an element can be only partially on the screen, we want
+    // to scroll by the distance between the top/bottom of the element and the
+    // top/bottom of the list respectively, rather than a fixed amount or to a
+    // specific index.
+    let distance;
+    if (selectedBounds.top < listBounds.top) {
+      distance = selectedBounds.top - listBounds.top;
+    } else {
+      distance = selectedBounds.bottom - listBounds.bottom;
+    }
+    list.scroll(0, currentScroll + distance);
   }
 
 


### PR DESCRIPTION
An alternate solution to that suggested in #290. Scrolling on the registry and grapher at some screen resolutions would lead to the item at the bottom not always being in view. This could also happen with the top element if the list had been offset manually. This PR scrolls by the distance between the element and where it should be rather than scrolling to fixed indices.
