### PR TITLE
Added a throttle to selectedDataset updates on Grapher.

### DIFF
--- a/client-js/app/elements/labrad-grapher.ts
+++ b/client-js/app/elements/labrad-grapher.ts
@@ -338,15 +338,15 @@ export class LabradGrapher extends polymer.Base {
 
     this.selectedThrottleTimeout = setTimeout(() => {
       this.selectedDataset = "";
-
       if (!this.selected) {
         return;
       }
 
-      if (this.selected.id.startsWith('dataset:')) {
-        const name = this.selected.id.substring(8);
-        this.fetchInfo(name);
+      const id = this.selected.id;
+      if (id.startsWith('dataset:')) {
+        const name = id.substring(8);
         this.selectedDataset = name;
+        this.fetchInfo(name);
       }
     }, THROTTLE_DELAY_SELECTED_DATASET);
   }

--- a/client-js/app/elements/labrad-grapher.ts
+++ b/client-js/app/elements/labrad-grapher.ts
@@ -51,7 +51,7 @@ export class LabradGrapher extends polymer.Base {
   @property({type: String})
   connectionError: string;
 
-  selectedThrottleTimeout: any = null;
+  selectedThrottleTimeout: number = null;
 
   target: HTMLElement = document.body;
 

--- a/client-js/app/elements/labrad-grapher.ts
+++ b/client-js/app/elements/labrad-grapher.ts
@@ -51,7 +51,7 @@ export class LabradGrapher extends polymer.Base {
   @property({type: String})
   connectionError: string;
 
-  selectedThrottleTimeout: NodeJS.Timer = null;
+  selectedThrottleTimeout: any = null;
 
   target: HTMLElement = document.body;
 


### PR DESCRIPTION
Currently every time you select an item in the Grapher, the `selectedDataset` computed property makes a call to the server and then renders all the info about that dataset. With the introduction of keyboard controls, holding a key leads to a very rapid shuffle through the selected datasets which hammers the server and lags the UI due to all the DOM updates.

This PR fixes that by adding a 100ms throttle to the `selectedDataset` update. The call to the server is delayed 100ms, and any future calls made within that window will cancel the request and create a new one. This means that you only call the server at the end of a scroll, making the UI much snappier and reducing calls to the server drastically.
