### PR TITLE
Clean up grapher param view styling.

### DIFF
--- a/client-js/app/elements/labrad-grapher.html
+++ b/client-js/app/elements/labrad-grapher.html
@@ -72,6 +72,7 @@
     #params tbody td {
       padding-top: 0.4em;
       padding-bottom: 0.4em;
+      vertical-align: top;
     }
     #params tbody td.value {
       word-wrap: break-word;

--- a/client-js/app/elements/labrad-grapher.html
+++ b/client-js/app/elements/labrad-grapher.html
@@ -64,17 +64,23 @@
       font-size: 24px;
       line-height: 45px;
     }
-    #params thead tr {
-      background-color: #7744AA;
+    #params thead th {
+      background-color: #3f51b5;
       color: white;
+      padding: 0.5em;
+    }
+    #params tbody td {
+      padding-top: 0.4em;
+      padding-bottom: 0.4em;
     }
     #params th,td {
       padding-left: 0.5em;
       padding-right: 0.5em;
     }
     .monospace {
-      font-family: courier;
+      font-family: "Roboto Mono", "Roboto", sans-serif;
       text-overflow: ellipsis;
+      font-size: 12px;
     }
     .row {
       cursor: pointer;
@@ -186,9 +192,9 @@
                 <tbody>
                 <template is="dom-repeat" items="{{selectedDatasetInfo.independents}}">
                   <tr>
-                    <td>{{item.label}}</td>
+                    <td class="monospace">{{item.label}}</td>
                     <td></td>
-                    <td>{{item.unit}}</td>
+                    <td class="monospace">{{item.unit}}</td>
                   </tr>
                 </template>
                 </tbody>
@@ -199,9 +205,9 @@
                 <tbody>
                 <template is="dom-repeat" items="{{selectedDatasetInfo.dependents}}">
                   <tr>
-                    <td>{{item.label}}</td>
-                    <td>{{item.legend}}</td>
-                    <td>{{item.unit}}</td>
+                    <td class="monospace">{{item.label}}</td>
+                    <td class="monospace">{{item.legend}}</td>
+                    <td class="monospace">{{item.unit}}</td>
                   </tr>
                 </template>
                 </tbody>

--- a/client-js/app/elements/labrad-grapher.html
+++ b/client-js/app/elements/labrad-grapher.html
@@ -65,7 +65,7 @@
       line-height: 45px;
     }
     #params thead th {
-      background-color: #3f51b5;
+      background-color: #673AB7;
       color: white;
       padding: 0.5em;
     }

--- a/client-js/app/elements/labrad-grapher.html
+++ b/client-js/app/elements/labrad-grapher.html
@@ -70,17 +70,20 @@
       padding: 0.5em;
     }
     #params tbody td {
-      padding-top: 0.4em;
-      padding-bottom: 0.4em;
+      padding-top: 0.5em;
+      padding-bottom: 0.5em;
       vertical-align: top;
+    }
+    #params tbody tr:nth-of-type(odd) {
+      background-color: #EEEEEE;
     }
     #params tbody td.value {
       word-wrap: break-word;
       word-break: break-all;
     }
     #params th,td {
-      padding-left: 0.5em;
-      padding-right: 0.5em;
+      padding-left: 0.7em;
+      padding-right: 0.7em;
     }
     .monospace {
       font-family: "Roboto Mono", "Roboto", sans-serif;

--- a/client-js/app/elements/labrad-grapher.html
+++ b/client-js/app/elements/labrad-grapher.html
@@ -73,6 +73,10 @@
       padding-top: 0.4em;
       padding-bottom: 0.4em;
     }
+    #params tbody td.value {
+      word-wrap: break-word;
+      word-break: break-all;
+    }
     #params th,td {
       padding-left: 0.5em;
       padding-right: 0.5em;
@@ -221,7 +225,7 @@
                 <template is="dom-repeat" items="{{selectedDatasetInfo.params}}">
                   <tr>
                     <td class="monospace">{{item.name}}</td>
-                    <td class="monospace">{{item.value}}</td>
+                    <td class="monospace value">{{item.value}}</td>
                   </tr>
                 </template>
                 </tbody>

--- a/client-js/app/elements/labrad-nodes.html
+++ b/client-js/app/elements/labrad-nodes.html
@@ -167,7 +167,7 @@
       padding: 4px;
     }
     thead tr {
-      background-color: #440088;
+      background-color: #673AB7;
       color: white;
     }
     tbody tr:nth-of-type(odd) {


### PR DESCRIPTION
The current UI for the grapher params is pretty ugly and inconsistent with the rest of the app.

This PR uses Roboto Mono as the monospace font, adds a bit more padding to space things a little nicer and changes the headings to be blue.
