### PR TITLE
Raise an error if saved credentials do not have a known 'kind'

### DIFF
--- a/client-js/app/scripts/app.ts
+++ b/client-js/app/scripts/app.ts
@@ -431,6 +431,9 @@ window.addEventListener('WebComponentsReady', () => {
             manager: manager
           });
           break;
+
+        default:
+          throw Error(`Unknown credential type: ${credential.kind}`);
       }
     } catch (error) {
       if (isPasswordError(error)) {


### PR DESCRIPTION
This fixes a problem with logging in to scalabrad-web v2 in a browser window that had previously been logged in to v1, since credentials were previously stored without a 'kind' property. These old credentials will now be rejected, so that the user will have to log in again when connecting to v2, but will at least be presented with a login box instead of a blank screen.

Fixes #299
