### PR TITLE
Fix splicing of lastData row in grapher

### DIFF
--- a/client-js/app/elements/labrad-plot.ts
+++ b/client-js/app/elements/labrad-plot.ts
@@ -859,7 +859,7 @@ export class Plot extends polymer.Base {
     this.dataLimits1D(data);
 
     if (this.lastData) {
-      data.splice(0, 1, this.lastData);
+      data.splice(0, 0, this.lastData);
     }
 
     const ob = this.getSceneObject();

--- a/server/src/test/scripts/data_demo.py
+++ b/server/src/test/scripts/data_demo.py
@@ -25,6 +25,7 @@ def demo(func):
     demos.append(func)
     return func
 
+
 @demo
 def demo_1d_exponential(dv):
     dv.new('demo_1d_exponential', ['x [ms]'], ['y [V]'])
@@ -37,6 +38,7 @@ def demo_1d_exponential(dv):
         dv.add([x, y])
         time.sleep(0.002)
 
+
 @demo
 def demo_1d_parabola(dv):
     dv.new('demo_1d_parabola', ['x [ms]'], ['y [V]'])
@@ -46,6 +48,7 @@ def demo_1d_parabola(dv):
         y = i**2 + i + random.random()*5000
         dv.add([x, y])
         time.sleep(0.002)
+
 
 @demo
 def demo_1d_parabola_2(dv):
@@ -57,6 +60,7 @@ def demo_1d_parabola_2(dv):
         dv.add([x, y])
         time.sleep(0.002)
 
+
 @demo
 def demo_1d_simple(dv):
     dv.new('demo_1d_simple', ['x [ms]'], ['y [V]'])
@@ -66,6 +70,18 @@ def demo_1d_simple(dv):
         y = 5 * math.sin(x) + random.random() - 0.5
         dv.add([x, y])
         time.sleep(0.002)
+
+
+@demo
+def demo_1d_slow(dv):
+    dv.new('demo_1d_slow', ['x [ms]'], ['Probability (0) []', 'Probability (1) []'])
+    add_params(dv)
+    for i in xrange(0, 1000):
+        x = i / 100.0
+        p0 = math.sin(x) + 0.2 * (i % 2)
+        p1 = 1 - p0
+        dv.add([x, p0, p1])
+        time.sleep(0.2 * random.random())
 
 
 @demo


### PR DESCRIPTION
The second argument to splice is the number of items to delete from the array. When splicing in the lastData row we were deleting the next row, and if there was only one row to begin with this would result in a data array of length 1, causing createLine to return null and the data point not to be plotted. This problem becomes more pronounced when the data arrives slowly, one row at a time, as often happens when taking real- world experimental data. Added a slow demo scan to test this scenario.

Fixes #298
