### PR TITLE
Add support for using OAuth access token to log in

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ lazy val server = project.in(file("server"))
     libraryDependencies ++= Seq(
       "org.scala-lang.modules" %% "scala-async" % "0.9.2",
       "org.jsoup" % "jsoup" % "1.9.2",
-      "org.labrad" %% "scalabrad" % "0.7.2"
+      "org.labrad" %% "scalabrad" % "0.7.3"
     ),
 
     // When running, connect std in and tell server to stop on EOF (ctrl+D).

--- a/client-js/app/scripts/app.ts
+++ b/client-js/app/scripts/app.ts
@@ -6,7 +6,7 @@ import "whatwg-fetch";
 import {Activity} from "./activity";
 import * as activities from "./activities";
 import {Credential, Password, OAuthToken, loadCredential, saveCredential, clearCredential} from "./credentials";
-import {ManagerApi, ManagerServiceJsonRpc} from "./manager";
+import {ManagerApi, ManagerServiceJsonRpc, OAuthInfo} from "./manager";
 import * as registry from "./registry";
 import * as datavault from "./datavault";
 import * as nodeApi from "./node";
@@ -328,10 +328,16 @@ window.addEventListener('WebComponentsReady', () => {
       doLogin();
     });
     if (app.allowOAuthLogin) {
-      const tokenType = authMethods.indexOf('oauth_access_token') >= 0 ? 'access' : 'id';
-      app.$.oauthButton.addEventListener('click', (event) => {
-        startOAuthLogin(mgr, manager, tokenType);
-      });
+      app.$.oauthButton.addEventListener('click', async (event) => {
+        try {
+          const oauthInfo = await mgr.oauthInfo({manager: manager});
+          const tokenType = authMethods.indexOf('oauth_access_token') >= 0 ? 'access' : 'id';
+          const rememberMe = app.$.rememberPassword.checked;
+          await startOAuthLogin(manager, oauthInfo, tokenType, rememberMe)
+          // Redirected to oauth login page, so we never get here.
+        } catch (error) {
+          app.loginError = error.message || error;
+        }
       });
     }
     app.$.loginDialog.open();
@@ -339,33 +345,31 @@ window.addEventListener('WebComponentsReady', () => {
     return promise;
   }
 
-  async function startOAuthLogin(mgr: ManagerApi, manager: string, tokenType: string) {
-    const rememberMe = app.$.rememberPassword.checked;
-    try {
-      const {clientId, clientSecret} = await mgr.oauthInfo({ manager: manager });
-      const redirectUri = `${location.protocol}//${location.host}${prefix}/oauth2callback`;
-      const params = {
-        'response_type': 'code',
-        'client_id': clientId,
-        'redirect_uri': redirectUri,
-        'scope': 'openid email profile',
-        'state': JSON.stringify({
-          path: location.pathname + location.search + location.hash,
-          manager: manager,
-          client_id: clientId,
-          client_secret: clientSecret,
-          redirect_uri: redirectUri,
-          remember_me: rememberMe,
-          token_type: tokenType
-        })
-      };
-      const baseUrl = 'https://accounts.google.com/o/oauth2/v2/auth'
-      const url = `${baseUrl}?${encodeQueryString(params)}`;
-      window.location.href = url;
-    } catch (error) {
-      app.loginError = error.message || error;
-      setTimeout(() => app.$.passwordInput.$.input.focus(), 0);
-    }
+  /**
+   * Start OAuth login flow by redirecting to oauth login page. Returns a
+   * promise that never fires since there's nothing to do after the redirect.
+   */
+  async function startOAuthLogin(manager: string, oauthInfo: OAuthInfo, tokenType: string, rememberMe: boolean) {
+    const redirectUri = `${location.protocol}//${location.host}${prefix}/oauth2callback`;
+    const params = {
+      'response_type': 'code',
+      'client_id': oauthInfo.clientId,
+      'redirect_uri': redirectUri,
+      'scope': 'openid email profile',
+      'state': JSON.stringify({
+        path: location.pathname + location.search + location.hash,
+        manager: manager,
+        client_id: oauthInfo.clientId,
+        client_secret: oauthInfo.clientSecret,
+        redirect_uri: redirectUri,
+        remember_me: rememberMe,
+        token_type: tokenType
+      })
+    };
+    const baseUrl = 'https://accounts.google.com/o/oauth2/v2/auth';
+    const url = `${baseUrl}?${encodeQueryString(params)}`;
+    window.location.href = url;
+    await promises.never();
   }
 
   async function finishOAuthLogin(queryString: string) {
@@ -415,7 +419,7 @@ window.addEventListener('WebComponentsReady', () => {
    * If the login fails due to an invalid password, we clear the credentials
    * from this storage object.
    */
-  async function attemptLogin(mgr: ManagerApi, manager: string, storage: Storage): Promise<void> {
+  async function attemptLogin(mgr: ManagerApi, manager: string, storage: Storage, rememberMe: boolean): Promise<void> {
     var credential = loadCredential(manager, storage);
     if (credential === null) {
       throw new Error('no credentials');
@@ -433,11 +437,25 @@ window.addEventListener('WebComponentsReady', () => {
             default:
               throw Error(`Unknown token type: ${tokenType}`);
           }
-          await mgr.oauthLogin({
-            token: token,
-            tokenType: tokenType,
-            manager: manager,
-          });
+          const expired = oauthCred.expiresAt < Date.now() + 60 * 1000;
+          if (tokenType === "access" && expired) {
+            // If access token is expired (or expires soon), restart the OAuth
+            // flow. This handles the common case where the labrad clientId is
+            // still authorized, so the redirect will succeed without any user
+            // interaction, basically like using a refresh token in the desktop
+            // flow (except that we don't get a refresh token in the web flow,
+            // alas). However, we don't want to get stuck in a loop if this
+            // fails, so we clear the credentials before attempting to login.
+            clearCredential(manager, storage);
+            await startOAuthLogin(manager, oauthCred, tokenType, rememberMe);
+            // Redirected to oauth login page, so we never get here.
+          } else {
+            await mgr.oauthLogin({
+              token: token,
+              tokenType: tokenType,
+              manager: manager,
+            });
+          }
           break;
 
         case 'username+password':
@@ -519,10 +537,10 @@ window.addEventListener('WebComponentsReady', () => {
     }
 
     try {
-      await attemptLogin(mgr, host, window.sessionStorage);
+      await attemptLogin(mgr, host, window.sessionStorage, false);
     } catch (e) {
       try {
-        await attemptLogin(mgr, host, window.localStorage);
+        await attemptLogin(mgr, host, window.localStorage, true);
       } catch (e) {
         if (topLevel) {
           await loginWithDialog(mgr, host);

--- a/client-js/app/scripts/credentials.ts
+++ b/client-js/app/scripts/credentials.ts
@@ -18,6 +18,7 @@ export interface OAuthToken {
   expiresAt: number;
   idToken: string;
   refreshToken?: string;
+  tokenType?: string;
 }
 
 export type Credential = Password | OAuthToken;

--- a/client-js/app/scripts/manager.ts
+++ b/client-js/app/scripts/manager.ts
@@ -48,7 +48,7 @@ export interface ManagerApi {
   authMethods(params: {manager: string}): Promise<string[]>;
   login(params: {username: string; password: string; manager: string}): Promise<void>;
   oauthInfo(params: {manager: string}): Promise<OAuthInfo>;
-  oauthLogin(params: {idToken: string; manager: string}): Promise<void>;
+  oauthLogin(params: {token: string; tokenType?: string; manager: string}): Promise<void>;
   ping(): Promise<void>;
   version(): Promise<string>;
   connections(): Promise<ConnectionInfo[]>;
@@ -88,7 +88,7 @@ export class ManagerServiceJsonRpc extends rpc.RpcService implements ManagerApi 
     return this.call<OAuthInfo>("oauthInfo", params);
   }
 
-  oauthLogin(params: {idToken: string; manager: string}): Promise<void> {
+  oauthLogin(params: {token: string; tokenType?: string; manager: string}): Promise<void> {
     return this.call<void>("oauthLogin", params);
   }
 

--- a/client-js/app/scripts/promises.ts
+++ b/client-js/app/scripts/promises.ts
@@ -1,7 +1,17 @@
 import {obligate} from './obligation';
 
+/**
+ * Return a promise that will fire after the given delay.
+ */
 export function sleep(delayMillis: number): Promise<void> {
   var {obligation, promise} = obligate<void>();
   setTimeout(() => obligation.resolve(), delayMillis);
   return promise;
+}
+
+/**
+ * Return a promise that will never fire.
+ */
+export function never(): Promise<void> {
+  return new Promise<void>((resolve, reject) => {});
 }

--- a/server/src/main/scala/org/labrad/browser/LabradConnection.scala
+++ b/server/src/main/scala/org/labrad/browser/LabradConnection.scala
@@ -59,8 +59,12 @@ class LabradConnection(
     doLogin(Password(username, password.toCharArray), manager)
   }
 
-  def oauthLogin(idToken: String, manager: String = ""): Unit = {
-    doLogin(OAuthToken(idToken), manager)
+  def oauthLogin(token: String, tokenType: String = "id", manager: String = ""): Unit = {
+    val credential = tokenType match {
+      case "id" => OAuthIdToken(token)
+      case "access" => OAuthAccessToken(token)
+    }
+    doLogin(credential, manager)
   }
 
   private def doLogin(credential: Credential, manager: String): Unit = {
@@ -158,7 +162,7 @@ class LabradConnection(
    */
   private def withTempConnection[A](manager: String)(f: Client => A): A = {
     val host = getHost(manager)
-    val cxn = new Client("Browser", host = host, credential = OAuthToken(""))
+    val cxn = new Client("Browser", host = host, credential = OAuthIdToken(""))
     cxn.connect(login = false)
     try {
       f(cxn)


### PR DESCRIPTION
Previously, we used id tokens for oauth login, but the manager supports access tokens as of labrad/scalabrad#75, so we add support for that here as well. Because the server gives us a proper expiration time for the access token, we can restart the oauth login flow automatically when the browser has an expired access token, which should reduce the number of times users have to click the "Login with google" button, especially users who keep scalabrad-web windows open for a long time.
