### PR TITLE
Update typescript to version 2.

### DIFF
--- a/client-js/app/scripts/app.ts
+++ b/client-js/app/scripts/app.ts
@@ -425,19 +425,17 @@ window.addEventListener('WebComponentsReady', () => {
       throw new Error('no credentials');
     }
     try {
-      // TODO(maffoo): TS2 compiler understands .kind; can then remove casts.
       switch (credential.kind) {
         case 'oauth_token':
-          const oauthCred = credential as OAuthToken;
-          const tokenType = oauthCred.tokenType || "id";
+          const tokenType = credential.tokenType || "id";
           var token: string;
           switch (tokenType) {
-            case "id": token = oauthCred.idToken; break;
-            case "access": token = oauthCred.accessToken; break;
+            case "id": token = credential.idToken; break;
+            case "access": token = credential.accessToken; break;
             default:
               throw Error(`Unknown token type: ${tokenType}`);
           }
-          const expired = oauthCred.expiresAt < Date.now() + 60 * 1000;
+          const expired = credential.expiresAt < Date.now() + 60 * 1000;
           if (tokenType === "access" && expired) {
             // If access token is expired (or expires soon), restart the OAuth
             // flow. This handles the common case where the labrad clientId is
@@ -447,7 +445,7 @@ window.addEventListener('WebComponentsReady', () => {
             // alas). However, we don't want to get stuck in a loop if this
             // fails, so we clear the credentials before attempting to login.
             clearCredential(manager, storage);
-            await startOAuthLogin(manager, oauthCred, tokenType, rememberMe);
+            await startOAuthLogin(manager, credential, tokenType, rememberMe);
             // Redirected to oauth login page, so we never get here.
           } else {
             await mgr.oauthLogin({
@@ -459,16 +457,12 @@ window.addEventListener('WebComponentsReady', () => {
           break;
 
         case 'username+password':
-          const passwordCred = credential as Password;
           await mgr.login({
-            username: passwordCred.username,
-            password: passwordCred.password,
+            username: credential.username,
+            password: credential.password,
             manager: manager
           });
           break;
-
-        default:
-          throw Error(`Unknown credential type: ${credential.kind}`);
       }
     } catch (error) {
       if (isAuthError(error)) {

--- a/client-js/app/scripts/credentials.ts
+++ b/client-js/app/scripts/credentials.ts
@@ -30,10 +30,12 @@ export type Credential = Password | OAuthToken;
  */
 export function loadCredential(manager: string, storage: Storage): Credential {
   try {
-    return JSON.parse(storage.getItem(storageKey(manager))) as Credential;
-  } catch (e) {
-    return null;
-  }
+    const obj = JSON.parse(storage.getItem(storageKey(manager)));
+    if (obj.kind === 'username+password' || obj.kind === 'oauth_token') {
+      return obj as Credential;
+    }
+  } catch (e) {}
+  return null;
 }
 
 /**

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -49,7 +49,7 @@
     "minimist": "^1.2.0",
     "require-dir": "^0.3.0",
     "run-sequence": "^1.0.2",
-    "typescript": "^1.8.0",
+    "typescript": "^2.0.3",
     "vulcanize": ">= 1.4.2"
   },
   "engines": {

--- a/client-js/test/spec/obligation-spec.ts
+++ b/client-js/test/spec/obligation-spec.ts
@@ -1,4 +1,4 @@
-import {Obligation, obligate} from '../app/scripts/obligation';
+import {Obligation, obligate} from '../../app/scripts/obligation';
 
 describe('Obligation', function() {
 

--- a/client-js/test/spec/ts-test-spec.ts
+++ b/client-js/test/spec/ts-test-spec.ts
@@ -1,6 +1,6 @@
 import {Agent} from './hello-world';
-import {Observable} from '../app/scripts/observable';
-import {Lifetime} from '../app/scripts/lifetime';
+import {Observable} from '../../app/scripts/observable';
+import {Lifetime} from '../../app/scripts/lifetime';
 
 /*
 * Example test


### PR DESCRIPTION
Lets us remove some type casts when dealing with credentials which are a tagged union type distinguished by the `kind` member. We have to add a check when we deserialize credentials from JSON, to ensure that the object has a valid `kind` field, but from there the type system takes over.
