### PR TITLE
Pin typescript to version 2.0.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ scala:
 jdk:
   - oraclejdk8
 env:
-  - NODE_VERSION=4.4.7
+  - NODE_VERSION=6.9.5
 cache:
   directories:
     - $HOME/node-v$NODE_VERSION-linux-x64

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -49,7 +49,7 @@
     "minimist": "^1.2.0",
     "require-dir": "^0.3.0",
     "run-sequence": "^1.0.2",
-    "typescript": "^2.0.3",
+    "typescript": "2.0.x",
     "vulcanize": ">= 1.4.2"
   },
   "engines": {


### PR DESCRIPTION
Previously, the typescript version was specified as `^2.0.3`, and such "caret" ranges allow for minor-version updates, so this was pulling in version `2.1.6`. By changing this to `2.0.x` we instead pull in the lastest release from the `2.0` series, currently `2.0.10`, which builds properly (see [here](https://travis-ci.org/labrad/scalabrad-web/builds/201240290)).

Fixes #324