### PR TITLE
Add support for restarting outdated servers

### DIFF
--- a/client-js/app/elements/labrad-nodes.html
+++ b/client-js/app/elements/labrad-nodes.html
@@ -108,6 +108,7 @@
             icon="star-border"
             on-click="toggleAutostart"
             title="Autostart: Off"></paper-icon-button>
+        <span>{{version}}</span>
       </span>
     </div>
   </template>
@@ -134,11 +135,18 @@
     </span>
 
     <span hidden$="{{active}}">
-      <paper-icon-button id="refresh" icon="av:replay"></paper-icon-button>
+      <paper-icon-button
+        id="refresh"
+        icon="settings"
+        title="Reload Node Configuration"></paper-icon-button>
       <paper-icon-button
         id="autostart"
         icon="av:playlist-play"
         title="Start All Autostart Servers"></paper-icon-button>
+      <paper-icon-button
+        id="outdated"
+        icon="update"
+        title="Restart All Outdated Servers"></paper-icon-button>
     </span>
   </template>
 </dom-module>
@@ -224,7 +232,6 @@
       <table>
         <thead>
           <th>Global Servers</th>
-          <th></th>
           <template is="dom-repeat"
                     items="{{nodeNames}}"
                     as="node"
@@ -238,7 +245,6 @@
                     as="server">
             <tr>
               <td class='name'>{{server.name}}</td>
-              <td class='version'>{{server.version}}</td>
               <template is="dom-repeat"
                         items="{{server.nodes}}"
                         as="node"
@@ -251,6 +257,7 @@
                       local
                       name={{server.name}}
                       server={{server}}
+                      version={{node.version}}
                       instance-name={{node.instanceName}}
                       node={{node.name}}
                       status={{node.status}}
@@ -267,7 +274,6 @@
 
         <thead>
           <th>Local Servers</th>
-          <th></th>
           <template is="dom-repeat" items="{{nodeNames}}">
             <th></th>
           </template>
@@ -276,7 +282,6 @@
           <template is="dom-repeat" items="{{localServersFiltered}}" as="server">
             <tr>
               <td class="name">{{server.name}}</td>
-              <td class="version">{{server.version}}</td>
               <template is="dom-repeat"
                         items="{{server.nodes}}"
                         as="node"
@@ -288,6 +293,7 @@
                       api={{api}}
                       name={{server.name}}
                       server={{server}}
+                      version={{node.version}}
                       instance-name={{node.instanceName}}
                       node={{node.name}}
                       status={{node.status}}

--- a/client-js/app/elements/labrad-nodes.html
+++ b/client-js/app/elements/labrad-nodes.html
@@ -68,8 +68,8 @@
       padding: 0px;
     }
     paper-spinner {
-      width: 18px;
-      height: 18px;
+      width: 16px;
+      height: 16px;
       top: 5px;
     }
     paper-icon-button.autostart {
@@ -121,8 +121,8 @@
       padding: 0px;
     }
     paper-spinner {
-      width: 18px;
-      height: 18px;
+      width: 16px;
+      height: 16px;
       top: 5px;
     }
   </style>

--- a/client-js/app/elements/labrad-nodes.ts
+++ b/client-js/app/elements/labrad-nodes.ts
@@ -275,7 +275,7 @@ interface ServerInfo {
   errorString: string;
   errorException: string;
   nodes: NodeServerStatus[];
-};
+}
 
 type NodeServerStatus = {
   name: string,

--- a/client-js/app/scripts/activities.ts
+++ b/client-js/app/scripts/activities.ts
@@ -419,9 +419,7 @@ export class NodesActivity implements Activity {
 
     var nodesInfo = await this.nodeApi.allNodes();
     for (const node of nodesInfo) {
-      var list = await this.nodeApi.autostartList(node.name);
-      node.autostartList = list;
-      elem.addItemToList(node);
+      elem.updateNode(node);
     }
 
     elem.places = this.places;

--- a/client-js/app/scripts/observable.ts
+++ b/client-js/app/scripts/observable.ts
@@ -40,4 +40,14 @@ export class Observable<A> {
       setTimeout(() => callback(value), 0);
     }
   }
+
+  /**
+   * Create an observable that will apply a function to values we emit.
+   */
+  map<B>(f: (A) => Promise<B>, lifetime?: Lifetime): Observable<B> {
+    const observable = new Observable<B>();
+    this.add(async (a) => observable.call(await f(a)), lifetime);
+    return observable;
+  }
 }
+

--- a/server/src/main/scala/org/labrad/browser/ApiBackend.scala
+++ b/server/src/main/scala/org/labrad/browser/ApiBackend.scala
@@ -78,11 +78,14 @@ class ApiBackend(config: LabradConnectionConfig)(implicit ec: ExecutionContext) 
       CALL                    .server_info                 .serverInfo
 
       CALL  org.labrad.node.allNodes       nodeApi.allNodes
+      CALL                 .getNodeStatus         .getNodeStatus
       CALL                 .refreshNode           .refreshNode
       CALL                 .autostartNode         .autostartNode
       CALL                 .autostartList         .autostartList
       CALL                 .autostartAdd          .autostartAdd
       CALL                 .autostartRemove       .autostartRemove
+      CALL                 .outdatedList          .outdatedList
+      CALL                 .outdatedRestart       .outdatedRestart
       CALL                 .restartServer         .restartServer
       CALL                 .startServer           .startServer
       CALL                 .stopServer            .stopServer


### PR DESCRIPTION
This also cleans up the implementation of the LabradNodes element. Among other things, we move the fetching of extra information like the autostart list and list of outdated servers into the NodeApi so that the ui element can just use the status info it gets without making additional api calls. As a result of these cleanups the nodes element is much more robust, for example the displayed server versions update properly when the node config is refreshed. This was a persistent annoyance with the previous implementation since it made it even harder to understand what versions of server were running where.

The outdated server support relies on the node changes here: https://github.com/labrad/pylabrad/pull/343. The web interface will still work with older nodes, but the outdated restart button will do nothing.

Unfortunately, the diff is pretty large; sorry about that.