### PR TITLE
Switch Travis from oraclejdk8 to openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 scala:
   - "2.11.7"
 jdk:
-  - oraclejdk8
+  - openjdk8
 env:
   - NODE_VERSION=6.9.5
 cache:


### PR DESCRIPTION
Closes #334.

I'm not sure if this will make Travis builds succeed rather than failing (I cannot test this as Travis builds on my fork don't have access to `$JSPM_GITHUB_AUTH_TOKEN`). However, it is a step in the right direction.