### PR TITLE
Add missing resolvers for jsonquote and scalabrad-manager

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val commonSettings = Seq(
   useJGit,
   git.useGitDescribe := true,
   scalaVersion := "2.11.7",
-  resolvers += "bintray" at "http://jcenter.bintray.com"
+  resolvers += Resolver.jcenterRepo
 )
 
 enablePlugins(GitVersioning)
@@ -11,8 +11,6 @@ lazy val jsonrpc = project.in(file("jsonrpc"))
   .settings(commonSettings)
   .settings(
     name := "scalabrad-web-jsonrpc",
-
-    resolvers += Resolver.jcenterRepo,
 
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-reflect" % scalaVersion.value,
@@ -27,8 +25,6 @@ lazy val server = project.in(file("server"))
   .settings(commonSettings)
   .settings(
     name := "scalabrad-web-server",
-
-    resolvers += Resolver.jcenterRepo,
 
     libraryDependencies ++= Seq(
       "org.scala-lang.modules" %% "scala-async" % "0.9.2",

--- a/build.sbt
+++ b/build.sbt
@@ -12,10 +12,7 @@ lazy val jsonrpc = project.in(file("jsonrpc"))
   .settings(
     name := "scalabrad-web-jsonrpc",
 
-    resolvers ++= Seq(
-      "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/",
-      Resolver.jcenterRepo
-    ),
+    resolvers += Resolver.jcenterRepo,
 
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-reflect" % scalaVersion.value,

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,10 @@ lazy val jsonrpc = project.in(file("jsonrpc"))
   .settings(
     name := "scalabrad-web-jsonrpc",
 
-    resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/",
+    resolvers ++= Seq(
+      "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/",
+      Resolver.bintrayRepo("maffoo", "maven")
+    ),
 
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-reflect" % scalaVersion.value,
@@ -27,6 +30,8 @@ lazy val server = project.in(file("server"))
   .settings(commonSettings)
   .settings(
     name := "scalabrad-web-server",
+
+    resolvers += Resolver.bintrayRepo("labrad", "maven"),
 
     libraryDependencies ++= Seq(
       "org.scala-lang.modules" %% "scala-async" % "0.9.2",

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ lazy val jsonrpc = project.in(file("jsonrpc"))
 
     resolvers ++= Seq(
       "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/",
-      Resolver.bintrayRepo("maffoo", "maven")
+      Resolver.jcenterRepo
     ),
 
     libraryDependencies ++= Seq(
@@ -31,7 +31,7 @@ lazy val server = project.in(file("server"))
   .settings(
     name := "scalabrad-web-server",
 
-    resolvers += Resolver.bintrayRepo("labrad", "maven"),
+    resolvers += Resolver.jcenterRepo,
 
     libraryDependencies ++= Seq(
       "org.scala-lang.modules" %% "scala-async" % "0.9.2",


### PR DESCRIPTION
Closes #332. This PR also replaces #333.

I also removed the Typesafe resolver as it seems to be deprecated.  `sbt server/run` builds fine without it. The only difference in sbt build output caused by removing the Typesafe resolver is

*  git version: changed from `2.0.6-2-g8f751bf` to `2.0.6-2-g8f751bf-SNAPSHOT`
*  scalabrad-web-jsonrpc version: changed from `scalabrad-web-jsonrpc_2.11;2.0.6-2-g8f751bf` to `scalabrad-web-jsonrpc_2.11;2.0.6-2-g8f751bf-SNAPSHOT`